### PR TITLE
chore: update .gitignore to exclude IDE files. #27

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# === Maven ===
 target/
 pom.xml.tag
 pom.xml.releaseBackup
@@ -6,12 +7,32 @@ pom.xml.next
 release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
-.mvn/timing.properties
-# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+
+# Maven Wrapper
+.mvn/
+!/.mvn/wrapper/maven-wrapper.properties
 .mvn/wrapper/maven-wrapper.jar
 
-# Eclipse m2e generated files
-# Eclipse Core
+# === IntelliJ IDEA ===
+.idea/
+*.iml
+*.iws
+out/
+
+# === Eclipse ===
 .project
-# JDT-specific (Eclipse Java Development Tools)
 .classpath
+.settings/
+
+
+# === OS / Editor-specific ===
+.DS_Store
+Thumbs.db
+*.log
+*.tmp
+*.swp
+*.bak
+*.orig
+
+# === Kotlin ===
+*.kotlin_module


### PR DESCRIPTION
This PR updates the .gitignore file to exclude IDE-specific files and folders (e.g. .idea/, *.iml) as well as common build artifacts.
These changes help prevent accidental commits of user-specific or generated files and ensure a cleaner version.