### PR TITLE
feat/board and boardcell: Add BoardCell class with state management and actions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,13 @@
 			<artifactId>kotlin-test-junit5</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!-- Mockito Core Dependency -->
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>5.14.2</version> <!-- Die Version kannst du nach Bedarf anpassen -->
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/kotlin/at/mankomania/server/model/Board.kt
+++ b/src/main/kotlin/at/mankomania/server/model/Board.kt
@@ -1,7 +1,7 @@
 package at.mankomania.server.model
 
 /**
- * @author eles17
+ * @author eles17, Angela Drucks
  * Represents the game board made up of multiple fields.
  *
  * There are two ways to create a board:

--- a/src/main/kotlin/at/mankomania/server/model/Board.kt
+++ b/src/main/kotlin/at/mankomania/server/model/Board.kt
@@ -30,5 +30,5 @@ class Board (val cells: List<BoardCell>) {
      * @param index The index of the field to retrieve.
      * @return The field at the given index, wrapped around if necessary.
      */
-    fun getField(index:Int): BoardCell = cells [index % cells.size]
+    fun getCell(index:Int): BoardCell = cells [index % cells.size]
 }

--- a/src/main/kotlin/at/mankomania/server/model/BoardCell.kt
+++ b/src/main/kotlin/at/mankomania/server/model/BoardCell.kt
@@ -13,13 +13,15 @@ import at.mankomania.server.controller.GameController
  * @property state The current state of the cell (FREE, OCCUPIED, etc.).
  * @property hasBranch Indicates whether the field allows the player to choose a different path (branch).
  * @property branchOptions Possible branch destination indices.
+ * @property action The action to be executed when the player lands on the cell.
  */
 
 data class BoardCell(
     val index:Int,
     var state: CellState = CellState.FREE,
     val hasBranch: Boolean,
-    val branchOptions: List<Int> = emptyList()
+    val branchOptions: List<Int> = emptyList(),
+    var action: CellAction? = null
 ) {
     /**
      * Handles a player landing on the cell.
@@ -29,4 +31,6 @@ data class BoardCell(
         action?.execute(player, gameController)
         state = CellState.OCCUPIED
     }
+
+
 }

--- a/src/main/kotlin/at/mankomania/server/model/BoardCell.kt
+++ b/src/main/kotlin/at/mankomania/server/model/BoardCell.kt
@@ -1,14 +1,32 @@
 /**
  * @file BoardCell.kt
- * @author eles17
- * @since
+ * @author eles17, Angela Drucks,
+ * @since 2025-04-02
  * @description Repräsentiert ein einzelnes Spielfeld (Zelle) inkl. Position und zugewiesener Action.
  */
 package at.mankomania.server.model
+
+import at.mankomania.server.controller.GameController
+
 /**
  * @property index The position of this field on the board (0-based).
+ * @property state The current state of the cell (FREE, OCCUPIED, etc.).
  * @property hasBranch Indicates whether the field allows the player to choose a different path (branch).
+ * @property branchOptions Possible branch destination indices.
  */
 
-// TOUPDATE: Replace with official Board Cell implementation once merged by [TeammateName]
-data class BoardCell(val index:Int, val hasBranch: Boolean, val branchOptions: List<Int> = emptyList())
+data class BoardCell(
+    val index:Int,
+    var state: CellState = CellState.FREE,
+    val hasBranch: Boolean,
+    val branchOptions: List<Int> = emptyList()
+) {
+    /**
+     * Handles a player landing on the cell.
+     * Executes the cell's action (if present) and then marks the cell as OCCUPIED.
+     */
+    fun landOn(player: Player, gameController: GameController) {
+        action?.execute(player, gameController)
+        state = CellState.OCCUPIED
+    }
+}

--- a/src/main/kotlin/at/mankomania/server/model/BoardCell.kt
+++ b/src/main/kotlin/at/mankomania/server/model/BoardCell.kt
@@ -2,7 +2,7 @@
  * @file BoardCell.kt
  * @author eles17, Angela Drucks,
  * @since 2025-04-02
- * @description Repräsentiert ein einzelnes Spielfeld (Zelle) inkl. Position und zugewiesener Action.
+ * @description Repräsentiert ein einzelnes Spielfeld (Cell) inkl. Position und zugewiesener Action.
  */
 package at.mankomania.server.model
 

--- a/src/main/kotlin/at/mankomania/server/model/CellAction.kt
+++ b/src/main/kotlin/at/mankomania/server/model/CellAction.kt
@@ -1,4 +1,20 @@
 package at.mankomania.server.model
 
-class CellAction {
+import at.mankomania.server.controller.GameController
+
+/**
+ * @file CellAction.kt
+ * @author Angela Drucks
+ * @since 2025-04-02
+ * @description Represents an action that can be performed when a player lands on a board cell.
+ */
+
+interface CellAction {
+
+    /**
+     * Executes the action for a player on the given game controller.
+     * @param player The player who landed on the cell.
+     * @param gameController The game controller managing the game state.
+     */
+    fun execute(player: Player, gameController: GameController)
 }

--- a/src/main/kotlin/at/mankomania/server/model/CellState.kt
+++ b/src/main/kotlin/at/mankomania/server/model/CellState.kt
@@ -1,0 +1,17 @@
+/**
+ * @file CellState.kt
+ * @author Angela Drucks
+ * @since 2025-04-02
+ * @description
+ */
+
+package at.mankomania.server.model
+
+/**
+ * Represents the state of a board cell.
+ */
+
+enum class CellState {
+    FREE,
+    OCCUPIED
+}

--- a/src/main/kotlin/at/mankomania/server/model/CellState.kt
+++ b/src/main/kotlin/at/mankomania/server/model/CellState.kt
@@ -2,7 +2,8 @@
  * @file CellState.kt
  * @author Angela Drucks
  * @since 2025-04-02
- * @description
+ * @description Represents the state of a board cell, which can either be FREE or OCCUPIED.
+ * This enum is used to track the current status of a board cell, indicating if it is available for a player to land on or already occupied.
  */
 
 package at.mankomania.server.model

--- a/src/main/kotlin/at/mankomania/server/model/Player.kt
+++ b/src/main/kotlin/at/mankomania/server/model/Player.kt
@@ -28,7 +28,7 @@ data class Player(
 
         //retrieve the field once and check for branch
         val currentField =
-            board.getField(position) //Board.getField(position) must return a Field with populated branchOptions if hasBranch == true
+            board.getCell(position) //Board.getField(position) must return a Field with populated branchOptions if hasBranch == true
         return if (currentField.hasBranch) {
             chooseBranch(currentField.branchOptions)
             true
@@ -45,7 +45,7 @@ data class Player(
      * @return True if the current field has a branch; false otherwise.
      */
     fun hasBranch(board: Board): Boolean {
-        return board.getField(position).hasBranch
+        return board.getCell(position).hasBranch
     }
 
     /**

--- a/src/test/kotlin/at/mankomania/server/model/BoardCellTest.kt
+++ b/src/test/kotlin/at/mankomania/server/model/BoardCellTest.kt
@@ -74,4 +74,5 @@ class BoardCellTest {
         assertEquals(CellState.OCCUPIED, branchCell.state)
     }
 
+
 }

--- a/src/test/kotlin/at/mankomania/server/model/BoardCellTest.kt
+++ b/src/test/kotlin/at/mankomania/server/model/BoardCellTest.kt
@@ -28,7 +28,7 @@ class BoardCellTest {
     @Test
     fun newBoardCellShouldHaveDefaultStateFree() {
         // Arrange: Create a new BoardCell; by default, a new cell should have state FREE
-        val boardCell = BoardCell(id = 1)
+        val boardCell = BoardCell(index = 1, hasBranch = false, branchOptions = emptyList())
 
         // Act: Get the state of the cell.
         val actualState = boardCell.state

--- a/src/test/kotlin/at/mankomania/server/model/BoardCellTest.kt
+++ b/src/test/kotlin/at/mankomania/server/model/BoardCellTest.kt
@@ -48,5 +48,22 @@ class BoardCellTest {
         assertEquals(CellState.OCCUPIED, boardCell.state, "BoardCell should transition to OCCUPIED after landOn.")
     }
 
+    @Test
+    fun landOnShouldUpdateStateRegardlessOfBranch() {
+        // Arrange: Create a branching cell
+        val branchCell = BoardCell(
+            index = 10,
+            hasBranch = true,
+            branchOptions = listOf(20, 25),
+            action = null
+        )
+        val player = Player("TestPlayer")
+
+        // Act
+        branchCell.landOn(player, gameControllerMock)
+
+        // Assert: Even though it's a branching cell, once the player lands, the state should become OCCUPIED
+        assertEquals(CellState.OCCUPIED, branchCell.state)
+    }
 
 }

--- a/src/test/kotlin/at/mankomania/server/model/BoardCellTest.kt
+++ b/src/test/kotlin/at/mankomania/server/model/BoardCellTest.kt
@@ -6,14 +6,6 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import kotlin.test.assertEquals
 
-// Assumptions:
-// - CellState, CellAction, BoardCell, and Player are defined in your production code.
-//   For example:
-//   enum class CellState { FREE, OCCUPIED }
-//   interface CellAction { fun performAction(player: Player) }
-//   data class BoardCell(val id: Int, var state: CellState = CellState.FREE, var action: CellAction? = null)
-//   data class Player(val name: String)
-
 class BoardCellTest {
 
     private lateinit var cellActionMock: CellAction
@@ -35,6 +27,25 @@ class BoardCellTest {
 
         // Assert: The actual state should be FREE
         assertEquals(CellState.FREE, actualState, "The default state of a new board cell should be FREE.")
+    }
+
+    @Test
+    fun landOnShouldInvokeActionAndSetStateToOccupied() {
+        // Arrange: Create a BoardCell with a mock action
+        val boardCell = BoardCell(
+            index = 2,
+            hasBranch = false,
+            branchOptions = emptyList(),
+            action = cellActionMock
+        )
+        val testPlayer = Player("TestPlayer")
+
+        // Act: landOn is called
+        boardCell.landOn(testPlayer, gameControllerMock)
+
+        // Assert: Verify that execute(...) was called and the state is now OCCUPIED
+        Mockito.verify(cellActionMock, Mockito.times(1)).execute(testPlayer, gameControllerMock)
+        assertEquals(CellState.OCCUPIED, boardCell.state, "BoardCell should transition to OCCUPIED after landOn.")
     }
 
 

--- a/src/test/kotlin/at/mankomania/server/model/BoardCellTest.kt
+++ b/src/test/kotlin/at/mankomania/server/model/BoardCellTest.kt
@@ -130,4 +130,21 @@ class BoardCellTest {
     }
 
 
+    @Test
+    fun getActionShouldReturnCurrentAction() {
+        // Arrange: Create a BoardCell with a mock action in the constructor
+        val boardCell = BoardCell(
+            index = 12,
+            hasBranch = false,
+            action = cellActionMock
+        )
+
+        // Act: Retrieve the current action
+        val currentAction = boardCell.action
+
+        // Assert: Confirm it matches the mock
+        assertEquals(cellActionMock, currentAction, "Getter should return the currently assigned action.")
+    }
+
+
 }

--- a/src/test/kotlin/at/mankomania/server/model/BoardCellTest.kt
+++ b/src/test/kotlin/at/mankomania/server/model/BoardCellTest.kt
@@ -93,6 +93,23 @@ class BoardCellTest {
     }
 
     @Test
+    fun setStateShouldUpdateCellState() {
+        val boardCell = BoardCell(
+            index = 10,
+            hasBranch = false
+        )
+
+        // Initially FREE
+        assertEquals(CellState.FREE, boardCell.state, "Initial cell state should be FREE.")
+
+        // Act: Set the state to OCCUPIED
+        boardCell.state = CellState.OCCUPIED
+
+        // Assert: The cell state should now be OCCUPIED
+        assertEquals(CellState.OCCUPIED, boardCell.state, "Cell state should be updated to OCCUPIED.")
+    }
+
+    @Test
     fun setActionShouldChangeCellAction() {
         val boardCell = BoardCell(
             index = 5,

--- a/src/test/kotlin/at/mankomania/server/model/BoardCellTest.kt
+++ b/src/test/kotlin/at/mankomania/server/model/BoardCellTest.kt
@@ -1,0 +1,29 @@
+package at.mankomania.server.model
+
+import at.mankomania.server.controller.GameController
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import kotlin.test.assertEquals
+
+// Assumptions:
+// - CellState, CellAction, BoardCell, and Player are defined in your production code.
+//   For example:
+//   enum class CellState { FREE, OCCUPIED }
+//   interface CellAction { fun performAction(player: Player) }
+//   data class BoardCell(val id: Int, var state: CellState = CellState.FREE, var action: CellAction? = null)
+//   data class Player(val name: String)
+
+class BoardCellTest {
+
+    private lateinit var cellActionMock: CellAction
+    private lateinit var gameControllerMock: GameController
+
+    @BeforeEach
+    fun setUp() {
+        cellActionMock = Mockito.mock(CellAction::class.java)
+        gameControllerMock = Mockito.mock(GameController::class.java)
+    }
+
+
+}

--- a/src/test/kotlin/at/mankomania/server/model/BoardCellTest.kt
+++ b/src/test/kotlin/at/mankomania/server/model/BoardCellTest.kt
@@ -9,6 +9,7 @@
 package at.mankomania.server.model
 
 import at.mankomania.server.controller.GameController
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
@@ -89,6 +90,26 @@ class BoardCellTest {
         // Assert: The state should be updated
         assertEquals(CellState.OCCUPIED, boardCell.state,
             "Setting the state to OCCUPIED should update the BoardCell's state correctly.")
+    }
+
+    @Test
+    fun setActionShouldChangeCellAction() {
+        val boardCell = BoardCell(
+            index = 5,
+            hasBranch = false,
+            branchOptions = emptyList(),
+            action = null
+        )
+
+        // Initially, action is null
+        assertNull(boardCell.action, "By default, the action should be null if not provided in the constructor.")
+
+        // Act: Assign a mock action
+        boardCell.action = cellActionMock
+
+        // Assert: The action should be updated
+        assertEquals(cellActionMock, boardCell.action,
+            "Setting the action should update the BoardCell's action.")
     }
 
 

--- a/src/test/kotlin/at/mankomania/server/model/BoardCellTest.kt
+++ b/src/test/kotlin/at/mankomania/server/model/BoardCellTest.kt
@@ -1,3 +1,11 @@
+/**
+ * @file BoardCellTest.kt
+ * @author Angela Drucks
+ * @since 2025-04-07
+ * @description Unit-Testklasse zur Überprüfung der Spielfeldlogik in [BoardCell], inklusive Konstruktor-Tests,
+ *              Branch-Logik und Modulo-basiertem Feldzugriff.
+ */
+
 package at.mankomania.server.model
 
 import at.mankomania.server.controller.GameController

--- a/src/test/kotlin/at/mankomania/server/model/BoardCellTest.kt
+++ b/src/test/kotlin/at/mankomania/server/model/BoardCellTest.kt
@@ -25,5 +25,17 @@ class BoardCellTest {
         gameControllerMock = Mockito.mock(GameController::class.java)
     }
 
+    @Test
+    fun newBoardCellShouldHaveDefaultStateFree() {
+        // Arrange: Create a new BoardCell; by default, a new cell should have state FREE
+        val boardCell = BoardCell(id = 1)
+
+        // Act: Get the state of the cell.
+        val actualState = boardCell.state
+
+        // Assert: The actual state should be FREE
+        assertEquals(CellState.FREE, actualState, "The default state of a new board cell should be FREE.")
+    }
+
 
 }

--- a/src/test/kotlin/at/mankomania/server/model/BoardCellTest.kt
+++ b/src/test/kotlin/at/mankomania/server/model/BoardCellTest.kt
@@ -74,5 +74,22 @@ class BoardCellTest {
         assertEquals(CellState.OCCUPIED, branchCell.state)
     }
 
+    @Test
+    fun setStateShouldChangeCellState() {
+        val boardCell = BoardCell(
+            index = 4,
+            hasBranch = false,
+            branchOptions = emptyList(),
+            action = null
+        )
+
+        // Act: Change the state
+        boardCell.state = CellState.OCCUPIED
+
+        // Assert: The state should be updated
+        assertEquals(CellState.OCCUPIED, boardCell.state,
+            "Setting the state to OCCUPIED should update the BoardCell's state correctly.")
+    }
+
 
 }

--- a/src/test/kotlin/at/mankomania/server/model/BoardTest.kt
+++ b/src/test/kotlin/at/mankomania/server/model/BoardTest.kt
@@ -59,6 +59,22 @@ class BoardTest {
         assertEquals(5, customBoard.size, "Custom board should have exactly 5 cells.")
     }
 
+    @Test
+    fun customBoardShouldAssignBranchOptionsCorrectly() {
+        // Indices 0, 2, 4 (even) are marked as hasBranch = true
+        // and have branchOptions = [index + 5]
+        val branchCells = customBoard.cells.filter { it.hasBranch }
+        assertEquals(3, branchCells.size, "Three cells should be marked with hasBranch = true (indices 0, 2, 4).")
+
+        branchCells.forEach { cell ->
+            val expectedOptions = listOf(cell.index + 5)
+            assertEquals(expectedOptions, cell.branchOptions,
+                "Branch options should be [index + 5] for cells with hasBranch = true.")
+        }
+    }
+
+
+
 
 
 

--- a/src/test/kotlin/at/mankomania/server/model/BoardTest.kt
+++ b/src/test/kotlin/at/mankomania/server/model/BoardTest.kt
@@ -1,4 +1,36 @@
+/**
+ * @file BoardTest.kt
+ * @author Angela Drucks
+ * @since 2025-04-07
+ * @description Unit-Testklasse zur Überprüfung der Spielfeldlogik in Board.kt, inklusive Konstruktor-Tests,
+ *              Branch-Logik und Modulo-basiertem Feldzugriff.
+ */
+
 package at.mankomania.server.model
 
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+
 class BoardTest {
+
+    private lateinit var defaultBoard: Board
+    private lateinit var customBoard: Board
+
+    @BeforeEach
+    fun setUp() {
+        // Constructor 1: Board of size 10, cells 3 and 7 are branch cells
+        defaultBoard = Board(10) { index -> index == 3 || index == 7 }
+
+        // Constructor 2: Manually constructed cells with specific branchOptions
+        val cells = List(5) { index ->
+            BoardCell(
+                index = index,
+                hasBranch = index % 2 == 0,
+                branchOptions = if (index % 2 == 0) listOf(index + 5) else emptyList()
+            )
+        }
+        customBoard = Board(cells)
+    }
 }

--- a/src/test/kotlin/at/mankomania/server/model/BoardTest.kt
+++ b/src/test/kotlin/at/mankomania/server/model/BoardTest.kt
@@ -33,4 +33,10 @@ class BoardTest {
         }
         customBoard = Board(cells)
     }
+
+    @Test
+    fun constructorWithSizeShouldCreateCorrectNumberOfCells() {
+        // Assert
+        assertEquals(10, defaultBoard.size, "Board constructed with size 10 should have 10 cells.")
+    }
 }

--- a/src/test/kotlin/at/mankomania/server/model/BoardTest.kt
+++ b/src/test/kotlin/at/mankomania/server/model/BoardTest.kt
@@ -39,4 +39,17 @@ class BoardTest {
         // Assert
         assertEquals(10, defaultBoard.size, "Board constructed with size 10 should have 10 cells.")
     }
+
+    @Test
+    fun constructorWithSizeShouldMarkBranchCells() {
+        // Cells 3 and 7 should be marked as branch cells
+        val branchCells = defaultBoard.cells.filter { it.hasBranch }
+        assertEquals(2, branchCells.size, "Exactly two cells should be marked as branch cells (indices 3 and 7).")
+
+        val branchIndices = branchCells.map { it.index }
+        assertTrue(
+            branchIndices.contains(3) && branchIndices.contains(7),
+            "Branch cells should be at indices 3 and 7."
+        )
+    }
 }

--- a/src/test/kotlin/at/mankomania/server/model/BoardTest.kt
+++ b/src/test/kotlin/at/mankomania/server/model/BoardTest.kt
@@ -74,7 +74,16 @@ class BoardTest {
     }
 
 
+    @Test
+    fun getCellShouldReturnCorrectCell() {
+        // For defaultBoard, test a straightforward index
+        val cellAtIndex3 = defaultBoard.getCell(3)
+        assertEquals(3, cellAtIndex3.index, "defaultBoard.getCell(3) should return the cell with index 3.")
 
+        // For customBoard, test an in-range index
+        val cellAtIndex2 = customBoard.getCell(2)
+        assertEquals(2, cellAtIndex2.index, "customBoard.getCell(2) should return the cell with index 2.")
+    }
 
 
 

--- a/src/test/kotlin/at/mankomania/server/model/BoardTest.kt
+++ b/src/test/kotlin/at/mankomania/server/model/BoardTest.kt
@@ -52,4 +52,14 @@ class BoardTest {
             "Branch cells should be at indices 3 and 7."
         )
     }
+
+    @Test
+    fun customBoardShouldHaveCorrectCellCount() {
+        // The customBoard was initialized with 5 cells
+        assertEquals(5, customBoard.size, "Custom board should have exactly 5 cells.")
+    }
+
+
+
+
 }

--- a/src/test/kotlin/at/mankomania/server/model/BoardTest.kt
+++ b/src/test/kotlin/at/mankomania/server/model/BoardTest.kt
@@ -1,0 +1,4 @@
+package at.mankomania.server.model
+
+class BoardTest {
+}

--- a/src/test/kotlin/at/mankomania/server/model/BoardTest.kt
+++ b/src/test/kotlin/at/mankomania/server/model/BoardTest.kt
@@ -85,6 +85,17 @@ class BoardTest {
         assertEquals(2, cellAtIndex2.index, "customBoard.getCell(2) should return the cell with index 2.")
     }
 
+    @Test
+    fun getCellShouldWrapIndexUsingModulo() {
+        // defaultBoard has size 10, so index 12 wraps to 2
+        val wrappedCell = defaultBoard.getCell(12)
+        assertEquals(2, wrappedCell.index, "Index 12 should wrap around to cell index 2 for a board of size 10.")
+
+        // customBoard has size 5, so index 7 wraps to 2
+        val wrappedCellCustom = customBoard.getCell(7)
+        assertEquals(2, wrappedCellCustom.index, "Index 7 should wrap around to cell index 2 for a board of size 5.")
+    }
+
 
 
 }


### PR DESCRIPTION
This PR introduces the BoardCell class with the following key features:

- State Management: BoardCell now has a state property with values FREE and OCCUPIED, allowing tracking of whether a cell is available or occupied.
- Branching Logic: Each cell can have branching options that allow players to choose different paths.
- Actions: A new CellAction interface allows specific actions to be executed when a player lands on a cell. The landOn method invokes the action and sets the cell’s state to OCCUPIED.
- Tests: Unit tests have been added to ensure that the state transitions and action executions are correctly handled, including tests for branching cells and state updates.
- Additionally, the Board class has been updated for consistency, with the getField method renamed to getCell.

WIP: This issue is still in progress, and the implementation for the full game board logic and WebSocket handling is not yet complete. The board structure has been set up, and basic player movement logic has been integrated, but further work is needed to finalize the handling of branching paths, edge cases, and WebSocket communication.