### PR TITLE
Feature/server-game-logic

### DIFF
--- a/src/main/kotlin/at/mankomania/server/controller/GameController.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/GameController.kt
@@ -1,4 +1,27 @@
+/**
+ * @file GameController.kt
+ * @author Angela Drucks
+ * @since 2025-05-06
+ * @description Verwaltet die Spiellogik für das Mankomania-Spiel,
+ * einschließlich der Steuerung der Spielerbewegung und der Ausführung
+ * von Zellenaktionen auf dem Spielfeld.
+ */
+
 package at.mankomania.server.controller
 
-class GameController {
+import at.mankomania.server.model.Board
+
+
+class GameController(val board: Board) {
+    fun startGame() {
+        // Spiel starten, Spieler platzieren, etc
+    }
+
+    fun movePlayer(playerId: String, steps: Int) {
+        // Spieler bewegen
+    }
+
+    fun landOnCell(playerId: String, cellIndex: Int) {
+        // Aktion ausführen, wenn Spieler auf einer Zelle landet
+    }
 }

--- a/src/main/kotlin/at/mankomania/server/controller/GameController.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/GameController.kt
@@ -2,9 +2,8 @@
  * @file GameController.kt
  * @author Angela Drucks
  * @since 2025-05-06
- * @description Verwaltet die Spiellogik für das Mankomania-Spiel,
- * einschließlich der Steuerung der Spielerbewegung und der Ausführung
- * von Zellenaktionen auf dem Spielfeld.
+ * @description Manages core Mankomania game logic, including player turns,
+ * movement (with branching), and execution of cell actions.
  */
 
 package at.mankomania.server.controller
@@ -19,23 +18,35 @@ class GameController(
     private val board: Board,
     private val players: List<Player>,
     private val bankService: BankService = BankService(),
-    private val notificationService: NotificationService = NotificationService()
+    private val notificationService: NotificationService
 ) {
+
+    private var currentPlayerIndex = 0
+    /**
+     * Called once when a game session starts.
+     */
     fun startGame() {
-        // notificationService.sendGameState(players)
+        // Broadcast initial state
+        notificationService.sendGameState(players)
     }
 
+    /**
+     * Rolls/moves the given player and handles branching or landing.
+     */
     fun movePlayer(playerId: String, steps: Int) {
-        // val player = players.find { it.name == playerId } ?: return
-        //val branched = player.move(steps, board)
-        //if (!branched) landOnCell(playerId, player.position)
-        //notificationService.sendPlayerMoved(playerId, player.position)
-
+        val player = players.find { it.name == playerId } ?: return
+        val branched = player.move(steps, board)
+        if (!branched) landOnCell(playerId, player.position)
+        notificationService.sendPlayerMoved(playerId, player.position)
     }
 
+    /**
+     * Executes cell action and notifies clients.
+     */
     fun landOnCell(playerId: String, cellIndex: Int) {
-        // val player = players.find { it.name == playerId } ?: return
-        //board.getCell(cellIndex).landOn(player, this)
-        //notificationService.sendPlayerLanded(playerId, cellIndex)
+        val player = players.find { it.name == playerId } ?: return
+        board.getCell(cellIndex).landOn(player, this)
+        notificationService.sendPlayerLanded(playerId, cellIndex)
     }
+
 }

--- a/src/main/kotlin/at/mankomania/server/controller/GameController.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/GameController.kt
@@ -10,18 +10,32 @@
 package at.mankomania.server.controller
 
 import at.mankomania.server.model.Board
+import at.mankomania.server.model.Player
+import at.mankomania.server.service.BankService
+import at.mankomania.server.service.NotificationService
 
 
-class GameController(val board: Board) {
+class GameController(
+    private val board: Board,
+    private val players: List<Player>,
+    private val bankService: BankService = BankService(),
+    private val notificationService: NotificationService = NotificationService()
+) {
     fun startGame() {
-        // Spiel starten, Spieler platzieren, etc
+        // notificationService.sendGameState(players)
     }
 
     fun movePlayer(playerId: String, steps: Int) {
-        // Spieler bewegen
+        // val player = players.find { it.name == playerId } ?: return
+        //val branched = player.move(steps, board)
+        //if (!branched) landOnCell(playerId, player.position)
+        //notificationService.sendPlayerMoved(playerId, player.position)
+
     }
 
     fun landOnCell(playerId: String, cellIndex: Int) {
-        // Aktion ausführen, wenn Spieler auf einer Zelle landet
+        // val player = players.find { it.name == playerId } ?: return
+        //board.getCell(cellIndex).landOn(player, this)
+        //notificationService.sendPlayerLanded(playerId, cellIndex)
     }
 }

--- a/src/main/kotlin/at/mankomania/server/controller/GameLobbyController.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/GameLobbyController.kt
@@ -1,4 +1,50 @@
+/*
+ * src/main/kotlin/at/mankomania/server/controller/GameLobbyController.kt
+ */
 package at.mankomania.server.controller
 
-class GameLobbyController {
+import at.mankomania.server.controller.dto.JoinDto
+import at.mankomania.server.controller.dto.LobbyStateDto
+import at.mankomania.server.controller.dto.StartDto
+import at.mankomania.server.controller.dto.GameStartedDto
+/**
+ * @file GameLobbyController.kt
+ * @author Angela Drucks
+ * @since 2025-05-07
+ * @description Provides REST endpoints for lobby management:
+ * allowing players to join a game lobby
+ * and to start a game session once minimum 2 players have joined.
+ */
+
+import at.mankomania.server.manager.GameSessionManager
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/lobby")
+class GameLobbyController(
+    private val sessionManager: GameSessionManager
+) {
+    @PostMapping("/{gameId}/join")
+    fun join(
+        @PathVariable gameId: String,
+        @RequestBody dto: JoinDto
+    ): ResponseEntity<LobbyStateDto> {
+        val added = sessionManager.joinGame(gameId, dto.playerName)
+        val playerNames = sessionManager.getPlayers(gameId).map { it.name }
+        val canStart = playerNames.size in 2..4
+        val state = LobbyStateDto(gameId, playerNames, canStart)
+        return if (added) ResponseEntity.ok(state)
+        else ResponseEntity.badRequest().body(state)
+    }
+
+    @PostMapping("/{gameId}/start")
+    fun start(
+        @PathVariable gameId: String,
+        @RequestBody dto: StartDto
+    ): ResponseEntity<GameStartedDto> {
+        val startPositions = sessionManager.startSession(gameId, dto.boardSize)
+            ?: return ResponseEntity.badRequest().build()
+        return ResponseEntity.ok(GameStartedDto(gameId, startPositions))
+    }
 }

--- a/src/main/kotlin/at/mankomania/server/controller/dto/GameStartedDto.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/dto/GameStartedDto.kt
@@ -1,0 +1,16 @@
+
+/**
+ * @file GameStartedDto.kt
+ * @author Angela Drucks
+ * @since 2025-05-07
+ * @description Response DTO sent when a game session successfully starts, containing starting positions for each player.
+ *
+ * @property gameId The identifier of the started game.
+ * @property startPositions The list of starting field indices for each player in join order.
+ */
+package at.mankomania.server.controller.dto
+
+data class GameStartedDto(
+    val gameId: String,
+    val startPositions: List<Int>
+)

--- a/src/main/kotlin/at/mankomania/server/controller/dto/JoinDto.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/dto/JoinDto.kt
@@ -1,0 +1,10 @@
+/**
+ * @file JoinDto.kt
+ * @author Angela Drucks
+ * @since 2025-05-07
+ * @description Data Transfer Object for joining a game lobby. Contains the name of the player who wants to join.
+ */
+
+package at.mankomania.server.controller.dto
+
+data class JoinDto(val playerName: String)

--- a/src/main/kotlin/at/mankomania/server/controller/dto/LobbyStateDto.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/dto/LobbyStateDto.kt
@@ -1,0 +1,17 @@
+/**
+ * @file LobbyStateDto.kt
+ * @author Angela Drucks
+ * @since 2025-05-07
+ * @description Represents the current state of a game lobby, including which players have joined and whether the game can start.
+ *
+ * @property gameId The identifier of the game lobby.
+ * @property players List of player names currently joined.
+ * @property canStart Flag indicating if the lobby meets the criteria to start the game (2–4 players).
+ */
+package at.mankomania.server.controller.dto
+
+data class LobbyStateDto(
+    val gameId: String,
+    val players: List<String>,
+    val canStart: Boolean
+)

--- a/src/main/kotlin/at/mankomania/server/controller/dto/StartDto.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/dto/StartDto.kt
@@ -1,0 +1,11 @@
+/**
+ * @file StartDto.kt
+ * @author Angela Drucks
+ * @since 2025-05-07
+ * @description Data Transfer Object for starting a game session. Contains the desired board size.
+ */
+package at.mankomania.server.controller.dto
+
+data class StartDto(
+    val boardSize: Int
+)

--- a/src/main/kotlin/at/mankomania/server/manager/DashboardManager.kt
+++ b/src/main/kotlin/at/mankomania/server/manager/DashboardManager.kt
@@ -1,2 +1,20 @@
+/**
+ * @file DashboardManager.kt
+ * @author Angela Drucks
+ * @since 2025-05-06
+ * @description Verantwortlich für das Verwalten und Anzeigen von Spielinformationen und Statistiken, wie etwa der aktiven Spiele und des Spielstands.
+ */
+
 package at.mankomania.server.manager
 
+class DashboardManager {
+    fun getActiveGames(): List<String> {
+        // Gibt eine Liste der aktiven Spiele zurück
+        return listOf("Game1", "Game2")
+    }
+
+    fun getPlayerStatus(gameId: String): String {
+        // Gibt den Status eines Spielers im Spiel zurück
+        return "Player 1: On cell 5"
+    }
+}

--- a/src/main/kotlin/at/mankomania/server/manager/GameSessionManager.kt
+++ b/src/main/kotlin/at/mankomania/server/manager/GameSessionManager.kt
@@ -9,6 +9,8 @@ package at.mankomania.server.manager
 import at.mankomania.server.controller.GameController
 import at.mankomania.server.model.BoardFactory
 import at.mankomania.server.model.Player
+import at.mankomania.server.service.BankService
+import at.mankomania.server.service.NotificationService
 import at.mankomania.server.service.StartingMoneyAssigner
 import org.springframework.stereotype.Service
 
@@ -16,13 +18,16 @@ import org.springframework.stereotype.Service
  * Manages player joining, session startup, and active game controllers.
  */
 @Service
-class GameSessionManager {
+class GameSessionManager(
+    private val moneyAssigner: StartingMoneyAssigner,
+    private val bankService: BankService,
+    private val notificationService: NotificationService
+) {
     private val activeGames = mutableMapOf<String, GameController>()
     private val gamePlayers = mutableMapOf<String, MutableList<Player>>()
-    private val moneyAssigner = StartingMoneyAssigner()
 
     /**
-     * A player joins a lobby. Returns false if name duplicated or max reached.
+     * A player joins a lobby. Returns false if name is duplicated or max reached (4).
      */
     fun joinGame(gameId: String, playerName: String): Boolean {
         val players = gamePlayers.getOrPut(gameId) { mutableListOf() }
@@ -32,37 +37,44 @@ class GameSessionManager {
     }
 
     /**
-     * List of players currently in lobby.
+     * Returns the list of players currently in the lobby.
      */
     fun getPlayers(gameId: String): List<Player> =
         gamePlayers[gameId]?.toList() ?: emptyList()
 
     /**
-     * Starts a session if 2–4 players are present, assigns money and positions, creates the game.
+     * Starts a session if 2–4 players are present. On success:
+     * 1. Assign starting money
+     * 2. Calculate and set fair start positions
+     * 3. Build the board and create a GameController
+     * 4. Start the game
      * Returns the list of start positions, or null on failure.
      */
     fun startSession(gameId: String, size: Int): List<Int>? {
         val players = gamePlayers[gameId] ?: return null
         if (players.size < 2) return null
 
-        // Assign starting money
+        // 1) Assign starting money
         moneyAssigner.assignToAll(players)
 
-        // Calculate fair, evenly spaced start positions
+        // 2) Calculate fair, evenly spaced start positions
         val startPositions = (0 until players.size).map { i -> (i * size) / players.size }
         players.forEachIndexed { idx, player -> player.position = startPositions[idx] }
 
-        // Create board and controller
+        // 3) Create board and controller
         val board = BoardFactory.createBoard(size) { idx -> idx % 10 == 0 }
-        val controller = GameController(board, players)
+        val controller = GameController(board, players, bankService, notificationService)
         activeGames[gameId] = controller
+
+        // 4) Start the game
         controller.startGame()
 
         return startPositions
     }
 
     /**
-     * Retrieves the GameController for an active session.
+     * Retrieves the GameController for an active session, or null if none exists.
      */
-    fun getGameController(gameId: String): GameController? = activeGames[gameId]
+    fun getGameController(gameId: String): GameController? =
+        activeGames[gameId]
 }

--- a/src/main/kotlin/at/mankomania/server/manager/GameSessionManager.kt
+++ b/src/main/kotlin/at/mankomania/server/manager/GameSessionManager.kt
@@ -8,30 +8,59 @@
 package at.mankomania.server.manager
 import at.mankomania.server.controller.GameController
 import at.mankomania.server.model.BoardFactory
+import at.mankomania.server.model.Player
+import at.mankomania.server.service.StartingMoneyAssigner
 
+/**
+ * Manages player joining, session startup, and active game controllers.
+ */
 class GameSessionManager {
     private val activeGames = mutableMapOf<String, GameController>()
+    private val gamePlayers = mutableMapOf<String, MutableList<Player>>()
+    private val moneyAssigner = StartingMoneyAssigner()
 
     /**
-     * Creates a new game with a given ID and board size.
-     *
-     * @param gameId The ID of the new game.
-     * @param size The number of fields on the board.
+     * A player joins a lobby. Returns false if name duplicated or max reached.
      */
-    fun createGame(gameId: String, size: Int) {
-        val board = BoardFactory.createBoard(size) { index -> index % 10 == 0 }  // Example: Every 10th cell has a branch
-        val gameController = GameController(board)
-        activeGames[gameId] = gameController
-        gameController.startGame()
+    fun joinGame(gameId: String, playerName: String): Boolean {
+        val players = gamePlayers.getOrPut(gameId) { mutableListOf() }
+        if (players.any { it.name == playerName } || players.size >= 4) return false
+        players.add(Player(name = playerName))
+        return true
     }
 
     /**
-     * Returns the GameController for a specific game.
-     *
-     * @param gameId The ID of the game.
-     * @return The GameController for the given game.
+     * List of players currently in lobby.
      */
-    fun getGameController(gameId: String): GameController? {
-        return activeGames[gameId]
+    fun getPlayers(gameId: String): List<Player> =
+        gamePlayers[gameId]?.toList() ?: emptyList()
+
+    /**
+     * Starts a session if 2–4 players are present, assigns money and positions, creates the game.
+     * Returns the list of start positions, or null on failure.
+     */
+    fun startSession(gameId: String, size: Int): List<Int>? {
+        val players = gamePlayers[gameId] ?: return null
+        if (players.size < 2) return null
+
+        // Assign starting money
+        moneyAssigner.assignToAll(players)
+
+        // Calculate fair, evenly spaced start positions
+        val startPositions = (0 until players.size).map { i -> (i * size) / players.size }
+        players.forEachIndexed { idx, player -> player.position = startPositions[idx] }
+
+        // Create board and controller
+        val board = BoardFactory.createBoard(size) { idx -> idx % 10 == 0 }
+        val controller = GameController(board, players)
+        activeGames[gameId] = controller
+        controller.startGame()
+
+        return startPositions
     }
+
+    /**
+     * Retrieves the GameController for an active session.
+     */
+    fun getGameController(gameId: String): GameController? = activeGames[gameId]
 }

--- a/src/main/kotlin/at/mankomania/server/manager/GameSessionManager.kt
+++ b/src/main/kotlin/at/mankomania/server/manager/GameSessionManager.kt
@@ -51,7 +51,7 @@ class GameSessionManager(
      * Returns the list of start positions, or null on failure.
      */
     fun startSession(gameId: String, size: Int): List<Int>? {
-        val players = gamePlayers[gameId] ?: return null
+        val players = gamePlayers[gameId]?.toList() ?: return null
         if (players.size < 2) return null
 
         // 1) Assign starting money

--- a/src/main/kotlin/at/mankomania/server/manager/GameSessionManager.kt
+++ b/src/main/kotlin/at/mankomania/server/manager/GameSessionManager.kt
@@ -1,1 +1,37 @@
+/**
+ * @file GameSessionManager.kt
+ * @author Angela Drucks
+ * @since 2025-05-06
+ * @description Manages game sessions, including creating new games and managing active sessions.
+ */
+
 package at.mankomania.server.manager
+import at.mankomania.server.controller.GameController
+import at.mankomania.server.model.BoardFactory
+
+class GameSessionManager {
+    private val activeGames = mutableMapOf<String, GameController>()
+
+    /**
+     * Creates a new game with a given ID and board size.
+     *
+     * @param gameId The ID of the new game.
+     * @param size The number of fields on the board.
+     */
+    fun createGame(gameId: String, size: Int) {
+        val board = BoardFactory.createBoard(size) { index -> index % 10 == 0 }  // Example: Every 10th cell has a branch
+        val gameController = GameController(board)
+        activeGames[gameId] = gameController
+        gameController.startGame()
+    }
+
+    /**
+     * Returns the GameController for a specific game.
+     *
+     * @param gameId The ID of the game.
+     * @return The GameController for the given game.
+     */
+    fun getGameController(gameId: String): GameController? {
+        return activeGames[gameId]
+    }
+}

--- a/src/main/kotlin/at/mankomania/server/manager/GameSessionManager.kt
+++ b/src/main/kotlin/at/mankomania/server/manager/GameSessionManager.kt
@@ -10,10 +10,12 @@ import at.mankomania.server.controller.GameController
 import at.mankomania.server.model.BoardFactory
 import at.mankomania.server.model.Player
 import at.mankomania.server.service.StartingMoneyAssigner
+import org.springframework.stereotype.Service
 
 /**
  * Manages player joining, session startup, and active game controllers.
  */
+@Service
 class GameSessionManager {
     private val activeGames = mutableMapOf<String, GameController>()
     private val gamePlayers = mutableMapOf<String, MutableList<Player>>()

--- a/src/main/kotlin/at/mankomania/server/model/Board.kt
+++ b/src/main/kotlin/at/mankomania/server/model/Board.kt
@@ -1,6 +1,7 @@
 package at.mankomania.server.model
 
 /**
+ * @file Board.kt
  * @author eles17, Angela Drucks
  * Represents the game board made up of multiple fields.
  *
@@ -13,6 +14,8 @@ package at.mankomania.server.model
  */
 
 // TOUPDATE: Replace with official Board implementation once merged by [TeammateName]
+
+
 class Board (val cells: List<BoardCell>) {
 
     val size: Int = cells.size

--- a/src/main/kotlin/at/mankomania/server/model/BoardCellFactory.kt
+++ b/src/main/kotlin/at/mankomania/server/model/BoardCellFactory.kt
@@ -1,0 +1,23 @@
+package at.mankomania.server.model
+
+/**
+ * @file BoardCellFactory.kt
+ * @author Angela Drucks
+ * @since 2025-05-06
+ * @description Factory that creates `BoardCell` instances.
+ */
+object BoardCellFactory {
+
+    /**
+     * Creates a new instance of `BoardCell` with the given parameters.
+     *
+     * @param index The index of the cell.
+     * @param hasBranch Indicates whether the cell has a branch.
+     * @param branchOptions The target indices of the branch, if present.
+     * @param action The action to be executed on the cell.
+     * @return A new `BoardCell` instance.
+     */
+    fun createBoardCell(index: Int, hasBranch: Boolean, branchOptions: List<Int> = emptyList(), action: CellAction? = null): BoardCell {
+        return BoardCell(index, hasBranch = hasBranch, branchOptions = branchOptions, action = action)
+    }
+}

--- a/src/main/kotlin/at/mankomania/server/model/BoardCellFactory.kt
+++ b/src/main/kotlin/at/mankomania/server/model/BoardCellFactory.kt
@@ -17,7 +17,12 @@ object BoardCellFactory {
      * @param action The action to be executed on the cell.
      * @return A new `BoardCell` instance.
      */
-    fun createBoardCell(index: Int, hasBranch: Boolean, branchOptions: List<Int> = emptyList(), action: CellAction? = null): BoardCell {
+    fun createBoardCell(
+        index: Int,
+        hasBranch: Boolean,
+        branchOptions: List<Int> = emptyList(),
+        action: CellAction?    = null
+    ): BoardCell {
         return BoardCell(index, hasBranch = hasBranch, branchOptions = branchOptions, action = action)
     }
 }

--- a/src/main/kotlin/at/mankomania/server/model/BoardFactory.kt
+++ b/src/main/kotlin/at/mankomania/server/model/BoardFactory.kt
@@ -1,0 +1,24 @@
+package at.mankomania.server.model
+
+/**
+ * @file BoardFactory.kt
+ * @author Angela Drucks
+ * @since 2025-05-06
+ * @description Factory that creates a complete game board.
+ */
+object BoardFactory {
+
+    /**
+     * Creates a complete game board with a predefined number of fields and a branching rule.
+     *
+     * @param size The number of fields on the game board.
+     * @param isBranchField A function that determines for each field whether it has a branch.
+     * @return A new `Board` object.
+     */
+    fun createBoard(size: Int, isBranchField: (Int) -> Boolean): Board {
+        val cells = List(size) { index ->
+            BoardCellFactory.createBoardCell(index, hasBranch = isBranchField(index))
+        }
+        return Board(cells)
+    }
+}

--- a/src/main/kotlin/at/mankomania/server/model/BoardFactory.kt
+++ b/src/main/kotlin/at/mankomania/server/model/BoardFactory.kt
@@ -17,7 +17,15 @@ object BoardFactory {
      */
     fun createBoard(size: Int, isBranchField: (Int) -> Boolean): Board {
         val cells = List(size) { index ->
-            BoardCellFactory.createBoardCell(index, hasBranch = isBranchField(index))
+            BoardCellFactory.createBoardCell(
+                index,
+                hasBranch     = isBranchField(index),
+                branchOptions = if (isBranchField(index))
+                    listOf((index + 5) % size)  // Beispiel-Branch-Ziel
+                else
+                    emptyList(),
+                action        = null            // später befüllen
+            )
         }
         return Board(cells)
     }

--- a/src/main/kotlin/at/mankomania/server/service/BankService.kt
+++ b/src/main/kotlin/at/mankomania/server/service/BankService.kt
@@ -1,4 +1,7 @@
 package at.mankomania.server.service
 
+import org.springframework.stereotype.Service
+
+@Service
 class BankService {
 }

--- a/src/main/kotlin/at/mankomania/server/service/NotificationService.kt
+++ b/src/main/kotlin/at/mankomania/server/service/NotificationService.kt
@@ -1,4 +1,35 @@
+/**
+ * @file NotificationService.kt
+ * @author Angela Drucks
+ * @since 2025-05-07
+ * @description Sends game updates (state, moves, landings) to clients via WebSocket/STOMP.
+ */
 package at.mankomania.server.service
 
-class NotificationService {
+import at.mankomania.server.model.Player
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.stereotype.Service
+
+/**
+ * Sends game updates to clients via WebSocket (STOMP).
+ */
+@Service
+class NotificationService(private val messagingTemplate: SimpMessagingTemplate) {
+    fun sendGameState(players: List<Player>) {
+        messagingTemplate.convertAndSend("/topic/game/state", players)
+    }
+
+    fun sendPlayerMoved(playerId: String, position: Int) {
+        messagingTemplate.convertAndSend(
+            "/topic/game/move",
+            mapOf("player" to playerId, "position" to position)
+        )
+    }
+
+    fun sendPlayerLanded(playerId: String, position: Int) {
+        messagingTemplate.convertAndSend(
+            "/topic/game/land",
+            mapOf("player" to playerId, "position" to position)
+        )
+    }
 }

--- a/src/main/kotlin/at/mankomania/server/service/StartingMoneyAssigner.kt
+++ b/src/main/kotlin/at/mankomania/server/service/StartingMoneyAssigner.kt
@@ -1,7 +1,9 @@
 package at.mankomania.server.service
 
 import at.mankomania.server.model.Player
+import org.springframework.stereotype.Service
 
+@Service
 class StartingMoneyAssigner {
 
     private val denominations: Map<Int, Int> = mapOf(

--- a/src/test/kotlin/at/mankomania/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/at/mankomania/server/controller/GameControllerTest.kt
@@ -1,0 +1,75 @@
+package at.mankomania.server.controller
+
+import at.mankomania.server.model.Board
+import at.mankomania.server.model.BoardCell
+import at.mankomania.server.model.BoardFactory
+import at.mankomania.server.model.Player
+import at.mankomania.server.service.NotificationService
+import at.mankomania.server.service.BankService
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.Mockito.verify
+
+
+@ExtendWith(MockitoExtension::class)
+class GameControllerTest {
+
+    private lateinit var board: Board
+    private lateinit var players: List<Player>
+    private lateinit var bankService: BankService
+    private lateinit var notificationService: NotificationService
+    private lateinit var controller: GameController
+
+    @BeforeEach
+    fun setUp() {
+        board = BoardFactory.createBoard(5) { false }
+        players = listOf(Player("Toni"), Player("Jorge"))
+        bankService = mock(BankService::class.java)
+        notificationService = mock(NotificationService::class.java)
+        controller = GameController(board, players, bankService, notificationService)
+    }
+
+    @Test
+    fun `startGame should broadcast initial state`() {
+        controller.startGame()
+        verify(notificationService).sendGameState(players)
+    }
+
+    @Test
+    fun `movePlayer on non-branch cell should land then move`() {
+        controller.movePlayer("Toni", 2)
+        verify(notificationService).sendPlayerLanded("Toni", 2)
+        verify(notificationService).sendPlayerMoved("Toni", 2)
+    }
+
+    @Test
+    fun `movePlayer on branch cell should only move`() {
+        // Board mit Branch auf Feld 2
+        board = Board(
+            listOf(
+                BoardCell(index = 0, hasBranch = false),
+                BoardCell(index = 1, hasBranch = false),
+                BoardCell(index = 2, hasBranch = true, branchOptions = listOf(4)),
+                BoardCell(index = 3, hasBranch = false),
+                BoardCell(index = 4, hasBranch = false)
+            )
+        )
+        controller = GameController(board, players, bankService, notificationService)
+
+        controller.movePlayer("Toni", 2)
+        verify(notificationService).sendPlayerMoved("Toni", 4)
+        verify(notificationService, never()).sendPlayerLanded(anyString(), anyInt())
+    }
+
+    @Test
+    fun `landOnCell always sends landing notification`() {
+        controller.landOnCell("Jorge", 3)
+        verify(notificationService).sendPlayerLanded("Jorge", 3)
+    }
+}

--- a/src/test/kotlin/at/mankomania/server/controller/GameLobbyControllerTest.kt
+++ b/src/test/kotlin/at/mankomania/server/controller/GameLobbyControllerTest.kt
@@ -1,0 +1,89 @@
+package at.mankomania.server.controller
+
+import at.mankomania.server.controller.dto.JoinDto
+import at.mankomania.server.controller.dto.StartDto
+import at.mankomania.server.manager.GameSessionManager
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.mockito.Mockito.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+
+
+@WebMvcTest(GameLobbyController::class)
+class GameLobbyControllerTest {
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @MockitoBean
+    private lateinit var sessionManager: GameSessionManager
+
+    private val mapper = jacksonObjectMapper()
+
+    @Test
+    fun `POST join returns 200 and lobby state when added`() {
+        val gameId = "g1"
+        given(sessionManager.joinGame(gameId, "Kafka")).willReturn(true)
+        given(sessionManager.getPlayers(gameId)).willReturn(listOf(
+            at.mankomania.server.model.Player("Kafka")
+        ))
+
+        mvc.perform(post("/lobby/$gameId/join")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(mapper.writeValueAsString(JoinDto("Kafka"))))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.gameId").value(gameId))
+            .andExpect(jsonPath("$.players[0]").value("Kafka"))
+            .andExpect(jsonPath("$.canStart").value(false))
+
+        verify(sessionManager).joinGame(gameId, "Kafka")
+    }
+
+    @Test
+    fun `POST join returns 400 when name duplicate or full`() {
+        val gameId = "g1"
+        given(sessionManager.joinGame(gameId, "Woolf")).willReturn(false)
+        given(sessionManager.getPlayers(gameId)).willReturn(emptyList())
+
+        mvc.perform(post("/lobby/$gameId/join")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(mapper.writeValueAsString(JoinDto("Woolf"))))
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `POST start returns 200 and positions when enough players`() {
+        val gameId = "g1"
+        val dto = StartDto(boardSize = 40)
+        given(sessionManager.startSession(gameId, 40)).willReturn(listOf(0,10))
+
+        mvc.perform(post("/lobby/$gameId/start")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(mapper.writeValueAsString(dto)))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.gameId").value(gameId))
+            .andExpect(jsonPath("$.startPositions[0]").value(0))
+            .andExpect(jsonPath("$.startPositions[1]").value(10))
+
+        verify(sessionManager).startSession(gameId, 40)
+    }
+
+    @Test
+    fun `POST start returns 400 when not enough players`() {
+        val gameId = "g1"
+        given(sessionManager.startSession(gameId, 50)).willReturn(null)
+
+        mvc.perform(post("/lobby/$gameId/start")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(mapper.writeValueAsString(StartDto(50))))
+            .andExpect(status().isBadRequest)
+    }
+
+}

--- a/src/test/kotlin/at/mankomania/server/manager/GameSessionManagerTest.kt
+++ b/src/test/kotlin/at/mankomania/server/manager/GameSessionManagerTest.kt
@@ -1,0 +1,91 @@
+package at.mankomania.server.manager
+
+import at.mankomania.server.controller.GameController
+import at.mankomania.server.model.Player
+import kotlin.test.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GameSessionManagerTest {
+
+    private lateinit var sessionManager: GameSessionManager
+    private val gameId = "testGame"
+
+    @BeforeEach
+    fun setUp() {
+        sessionManager = GameSessionManager()
+    }
+
+    @Test
+    fun testJoinGameAddsNewPlayersAndPreventsDuplicates() {
+        assertTrue(sessionManager.joinGame(gameId, "Franz"))
+        assertTrue(sessionManager.joinGame(gameId, "Kafka"))
+        //duplicate one:
+        assertFalse(sessionManager.joinGame(gameId, "Franz"))
+
+        val players = sessionManager.getPlayers(gameId)
+        assertEquals(2, players.size)
+        assertEquals(listOf("Franz", "Kafka"), players.map(Player::name))
+    }
+
+    @Test
+    fun testJoinGameRejectsMoreThan4Players() {
+        // add 4 distinct names
+        listOf("A", "B", "C", "D").forEach { name ->
+            assertTrue(sessionManager.joinGame(gameId, name))
+        }
+        // fifth player should be rejected
+        assertFalse(sessionManager.joinGame(gameId, "E"))
+        assertEquals(4, sessionManager.getPlayers(gameId).size)
+    }
+
+    @Test
+    fun testStartSessionReturnsNullForNonexistentLobby() {
+        // no players at all
+        assertNull(sessionManager.startSession("noLobby", 40))
+    }
+
+    @Test
+    fun testStartSessionReturnsNullWhenOnlyOnePlayer() {
+        // join only one player
+        sessionManager.joinGame(gameId, "Solo")
+        assertNull(sessionManager.startSession(gameId, 40))
+    }
+
+    @Test
+    fun testStartSessionAssignsCorrectStartPositions() {
+        // join 3 players directly in this test
+        listOf("P1", "P2", "P3").forEach { sessionManager.joinGame(gameId, it) }
+        val positions = sessionManager.startSession(gameId, 40)
+        assertNotNull(positions)
+        // expect evenly spaced positions: [0, 13, 26]
+        assertEquals(listOf(0, 13, 26), positions)
+    }
+
+    @Test
+    fun testStartSessionCreatesGameController() {
+        // join 3 players directly in this test
+        listOf("P1", "P2", "P3").forEach { sessionManager.joinGame(gameId, it) }
+        sessionManager.startSession(gameId, 40)
+        val controller = sessionManager.getGameController(gameId)
+        assertNotNull(controller)
+        assertTrue(controller is GameController)
+    }
+
+    @Test
+    fun testGetPlayersReturnsEmptyListForUnknownLobby() {
+        assertTrue(sessionManager.getPlayers("unknown").isEmpty())
+    }
+
+
+
+
+
+
+
+
+
+
+
+
+}

--- a/src/test/kotlin/at/mankomania/server/manager/GameSessionManagerTest.kt
+++ b/src/test/kotlin/at/mankomania/server/manager/GameSessionManagerTest.kt
@@ -2,9 +2,13 @@ package at.mankomania.server.manager
 
 import at.mankomania.server.controller.GameController
 import at.mankomania.server.model.Player
+import at.mankomania.server.service.BankService
+import at.mankomania.server.service.NotificationService
+import at.mankomania.server.service.StartingMoneyAssigner
 import kotlin.test.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
 
 class GameSessionManagerTest {
 
@@ -13,14 +17,22 @@ class GameSessionManagerTest {
 
     @BeforeEach
     fun setUp() {
-        sessionManager = GameSessionManager()
+        // Dependencies für den Manager bereitstellen (Bank, MoneyAssigner, Notification sind beans im echten App-Kontext)
+        val moneyAssigner = StartingMoneyAssigner()
+        val bankService = BankService()
+        val notificationService = mock(NotificationService::class.java)
+
+        sessionManager = GameSessionManager(
+            moneyAssigner,
+            bankService,
+            notificationService
+        )
     }
 
     @Test
     fun testJoinGameAddsNewPlayersAndPreventsDuplicates() {
         assertTrue(sessionManager.joinGame(gameId, "Franz"))
         assertTrue(sessionManager.joinGame(gameId, "Kafka"))
-        //duplicate one:
         assertFalse(sessionManager.joinGame(gameId, "Franz"))
 
         val players = sessionManager.getPlayers(gameId)


### PR DESCRIPTION
@all:
_A pull request has been opened to trigger CI checks, but these changes are still a work in progress and do not need to be merged yet. Feel free to review the tests and CI results before approving—and if you need any of this functionality now, you are welcome to check out or pull the feature/server-game-logic branch directly._

### What I did so far:

**Board & Cell Factories**

- Introduced BoardFactory and BoardCellFactory for clean board/cell creation.
- Moved that logic out of GameSessionManager to respect single responsibility.

**GameSessionManager & Lobby Flow**

- Replaced the old createGame(...) with startSession(...), which:

1. Enforces 2–4 players per lobby
2. Assigns starting money
3.  Calculates fair, evenly spaced start positions (we assume any prototype game board with about 40 cells, and 4 branching cells (features))
4. Builds the board and initializes the GameController with the player list

**GameController Signature**

- Updated to accept a List<Player> plus optional BankService and NotificationService.
- Stubs for startGame(), movePlayer(), and landOnCell() have been added for future logic.

**Unit Tests**

Added GameSessionManagerTest covering:
- Player joining rules (no duplicates, max 4)
- Lobby queries (getPlayers)
- startSession edge cases (too few players or nonexistent lobby)
- Valid session start (start positions and controller registration)

