### PR TITLE
feat(websocket): add ClientCounter.kt and PresenceListener.kt

### DIFF
--- a/src/main/kotlin/at/mankomania/server/websocket/ClientCounter.kt
+++ b/src/main/kotlin/at/mankomania/server/websocket/ClientCounter.kt
@@ -1,0 +1,12 @@
+package at.mankomania.server.websocket
+
+import org.springframework.stereotype.Component
+import java.util.concurrent.atomic.AtomicInteger
+
+@Component
+class ClientCounter {
+    private val counter = AtomicInteger(0)
+    fun increment(): Int = counter.incrementAndGet()
+    fun decrement(): Int = counter.decrementAndGet()
+    fun get(): Int = counter.get()
+}

--- a/src/main/kotlin/at/mankomania/server/websocket/PresenceListener.kt
+++ b/src/main/kotlin/at/mankomania/server/websocket/PresenceListener.kt
@@ -1,0 +1,28 @@
+package at.mankomania.server.websocket
+
+import org.springframework.context.event.EventListener
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.stereotype.Component
+import org.springframework.web.socket.messaging.SessionConnectEvent
+import org.springframework.web.socket.messaging.SessionDisconnectEvent
+
+@Component
+class PresenceListener(
+    private val counter: ClientCounter,
+    private val template: SimpMessagingTemplate
+) {
+
+    @EventListener
+    fun handleConnect(event: SessionConnectEvent) {
+        broadcast(counter.increment())
+    }
+
+    @EventListener
+    fun handleDisconnect(event: SessionDisconnectEvent) {
+        broadcast(counter.decrement())
+    }
+
+    private fun broadcast(current: Int) {
+        template.convertAndSend("/topic/clientCount", current)
+    }
+}

--- a/src/test/kotlin/at/mankomania/server/websocket/PresenceListenerTest.kt
+++ b/src/test/kotlin/at/mankomania/server/websocket/PresenceListenerTest.kt
@@ -1,0 +1,47 @@
+package at.mankomania.server.websocket
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mockito.*
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.web.socket.messaging.SessionConnectEvent
+import org.springframework.web.socket.messaging.SessionDisconnectEvent
+
+@ExtendWith(MockitoExtension::class)
+class PresenceListenerTest {
+
+    // Mockito mock, relaxed by default
+    private val template: SimpMessagingTemplate = mock(SimpMessagingTemplate::class.java)
+    private val counter = ClientCounter()
+
+    private lateinit var listener: PresenceListener
+
+    @BeforeEach
+    fun setUp() {
+        listener = PresenceListener(counter, template)
+    }
+
+    @Test
+    fun `handleConnect increments counter and broadcasts`() {
+        listener.handleConnect(mock(SessionConnectEvent::class.java))
+
+        assertEquals(1, counter.get())
+        verify(template).convertAndSend("/topic/clientCount", 1)
+    }
+
+    @Test
+    fun `handleDisconnect decrements counter and broadcasts`() {
+        // first client joins
+        listener.handleConnect(mock(SessionConnectEvent::class.java))
+        clearInvocations(template)
+
+        // then leaves
+        listener.handleDisconnect(mock(SessionDisconnectEvent::class.java))
+
+        assertEquals(0, counter.get())
+        verify(template).convertAndSend("/topic/clientCount", 0)
+    }
+}


### PR DESCRIPTION
Adds a simple client-counter metric to the server.

1. ClientCounter holds an atomic number of currently connected clients.
2. PresenceListener listens for WebSocket connect / disconnect events, updates the counter, and broadcasts the new value on /topic/clientCount.

**Purpose:** Let the mobile app (or any STOMP client) subscribe to that topic and see how many clients are connected in real time—handy for quickly testing whether joins and leaves are registered correctly.