### PR TITLE
Feature/6 dice start my turn logic

### DIFF
--- a/src/main/kotlin/at/mankomania/server/controller/GameController.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/GameController.kt
@@ -44,13 +44,13 @@ class GameController(
     }
 
     /**
-    * Calculates the result of a player's move for the UI, including updated position,
-    * field description, and other players on the same field.
-    *
-    * @param playerId The name of the player who is moving.
-    * @param steps Number of steps the player will move.
-    * @return A MoveResult DTO with position and field data, or null if player not found.
-    **/
+     * Calculates the result of a player's move for the UI, including updated position,
+     * field description, and other players on the same field.
+     *
+     * @param playerId The name of the player who is moving.
+     * @param steps Number of steps the player will move.
+     * @return A MoveResult DTO with position and field data, or null if player not found.
+     **/
     fun computeMoveResult(playerId: String, steps: Int): MoveResult? {
         val player = players.find{ it.name == playerId} ?: return null
         val oldPos = player.position
@@ -68,6 +68,14 @@ class GameController(
             playersOnField = others
         )
     }
+
+    /**
+     * Retrieves the Player object by ID for state updates (e.g., recording dice history).
+     *
+     * @param playerId the identifier of the player
+     * @return the Player instance or null if not found
+     */
+    fun getPlayer(playerId: String): Player? = players.find { it.name == playerId }
 
     /**
      * Executes cell action and notifies clients.

--- a/src/main/kotlin/at/mankomania/server/controller/PlayerController.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/PlayerController.kt
@@ -4,9 +4,14 @@ package at.mankomania.server.controller
  * @author eles17
  * @since 25.4.2025
  * @description
- *  PlayerController is responsible for handling player-specific actions such as rolling dice.
- *  It listens to WebSocket messages and sends back real-time results using messaging topics.
- *  The controller is designed for extensibility as more player actions (e.g., movement, purchases) are added.
+ * PlayerController handles player-specific WebSocket messages, such as rolling dice.
+ *
+ * It listens to incoming STOMP messages (e.g., "/app/rollDice") and processes the requested action.
+ * Once the dice are rolled, the result is logged, stored in the player's history, and broadcasted
+ * to the appropriate WebSocket topic (e.g., "/topic/diceResult/{playerId}").
+ *
+ * This controller is designed for extensibility as the game adds more player-driven features,
+ * such as movement, mini-games, and purchases.
  */
 import at.mankomania.server.model.Player
 import at.mankomania.server.util.DefaultDiceStrategy
@@ -17,6 +22,20 @@ import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Controller
 
 
+/**
+ * Handles a WebSocket message for rolling dice on behalf of a specific player.
+ *
+ * @param playerId the unique identifier of the player (sent from the client).
+ *
+ * Behavior:
+ * - Finds the player using the provided ID.
+ * - Rolls two dice using the game's DiceStrategy.
+ * - Stores the result in the player's history.
+ * - Logs the rolled values to the console.
+ * - Sends the result to the client subscribed to "/topic/diceResult/{playerId}".
+ *
+ * This method enables real-time, turn-based feedback for multiplayer gameplay.
+ */
 @Controller
 class PlayerController(private val messagingTemplate: SimpMessagingTemplate) {
 

--- a/src/main/kotlin/at/mankomania/server/controller/PlayerController.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/PlayerController.kt
@@ -1,4 +1,3 @@
-
 package at.mankomania.server.controller
 
 import at.mankomania.server.controller.dto.DiceMoveResultDto
@@ -10,13 +9,14 @@ import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Controller
 
+
 /**
  * @file PlayerController.kt
  * @author eles17
  * @since 25.04.2025
  * @description
  * PlayerController handles WebSocket-based actions triggered by players, such as rolling dice.
- * When a dice roll is received from the client, it applies movement logic and sends back
+ * When a die roll is received from the client, it applies movement logic and sends back
  * a combined result (dice + field) via STOMP to the client.
  *
  * This controller delegates all gameplay logic to GameSessionManager and GameController.
@@ -36,7 +36,7 @@ class PlayerController(
      */
     @MessageMapping("/rollDice")
     fun handleDiceRoll(@Payload playerId: String) {
-        val gameId = "default" // TO BE DONE: Replace with session-based or mapped game ID
+        val gameId = "default" // MUST BE IMPLEMENTED: Replace with session-based or mapped game ID
 
         val controller = sessionManager.getGameController(gameId)
         if (controller == null) {

--- a/src/main/kotlin/at/mankomania/server/controller/PlayerController.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/PlayerController.kt
@@ -1,19 +1,8 @@
+
 package at.mankomania.server.controller
-/**
- * @file PlayerController.kt
- * @author eles17
- * @since 25.4.2025
- * @description
- * PlayerController handles player-specific WebSocket messages, such as rolling dice.
- *
- * It listens to incoming STOMP messages (e.g., "/app/rollDice") and processes the requested action.
- * Once the dice are rolled, the result is logged, stored in the player's history, and broadcasted
- * to the appropriate WebSocket topic (e.g., "/topic/diceResult/{playerId}").
- *
- * This controller is designed for extensibility as the game adds more player-driven features,
- * such as movement, mini-games, and purchases.
- */
-import at.mankomania.server.model.Player
+
+import at.mankomania.server.controller.dto.DiceMoveResultDto
+import at.mankomania.server.manager.GameSessionManager
 import at.mankomania.server.util.DefaultDiceStrategy
 import at.mankomania.server.util.Dice
 import org.springframework.messaging.handler.annotation.MessageMapping
@@ -21,51 +10,63 @@ import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Controller
 
-
 /**
- * Handles a WebSocket message for rolling dice on behalf of a specific player.
+ * @file PlayerController.kt
+ * @author eles17
+ * @since 25.04.2025
+ * @description
+ * PlayerController handles WebSocket-based actions triggered by players, such as rolling dice.
+ * When a dice roll is received from the client, it applies movement logic and sends back
+ * a combined result (dice + field) via STOMP to the client.
  *
- * @param playerId the unique identifier of the player (sent from the client).
- *
- * Behavior:
- * - Finds the player using the provided ID.
- * - Rolls two dice using the game's DiceStrategy.
- * - Stores the result in the player's history.
- * - Logs the rolled values to the console.
- * - Sends the result to the client subscribed to "/topic/diceResult/{playerId}".
- *
- * This method enables real-time, turn-based feedback for multiplayer gameplay.
+ * This controller delegates all gameplay logic to GameSessionManager and GameController.
  */
 @Controller
-class PlayerController(private val messagingTemplate: SimpMessagingTemplate) {
-
-    //Uses the default strategy dor generating dice rolls
+class PlayerController(
+    private val messagingTemplate: SimpMessagingTemplate,
+    private val sessionManager: GameSessionManager
+) {
+    // Dice roller using the default (random) strategy
     private val dice = Dice(DefaultDiceStrategy())
-    //Temporary player storage; should be replaced by proper session/player management
-    private val players = mutableMapOf<String, Player>()
 
-
-    //temporary mock for testing
-    init{
-        players["blue"] = Player("blue")
-    }
+    /**
+     * Handles incoming WebSocket dice roll messages from the frontend.
+     *
+     * @param playerId the identifier of the player who initiated the dice roll
+     */
     @MessageMapping("/rollDice")
     fun handleDiceRoll(@Payload playerId: String) {
-        val player = players[playerId]
-        if (player == null) {
-            println("Player not found: $playerId")
+        val gameId = "default" // TO BE DONE: Replace with session-based or mapped game ID
+
+        val controller = sessionManager.getGameController(gameId)
+        if (controller == null) {
+            println("Game not found for gameId: $gameId")
             return
         }
-        //roll dice using strategy
-        val result = dice.roll()
 
-        player.recordDiceRoll(result)
+        // Roll the dice
+        val diceResult = dice.roll()
 
-        //log
-        println("Player $playerId rolled Dice: ${result.die1} + ${result.die2} = ${result.sum}")
+        // Apply movement logic and get resulting field data
+        val moveResult = controller.computeMoveResult(playerId, diceResult.sum)
+        if (moveResult == null) {
+            println("Move failed for player: $playerId")
+            return
+        }
 
-        //send the result to the player via STOMP
-        messagingTemplate.convertAndSend("/topic/diceResult/$playerId", result)
+        // Create response DTO containing dice result + move result
+        val dto = DiceMoveResultDto(
+            playerId = playerId,
+            die1 = diceResult.die1,
+            die2 = diceResult.die2,
+            sum = diceResult.sum,
+            fieldIndex = moveResult.newPosition,
+            fieldType = moveResult.fieldType,
+            fieldDescription = moveResult.fieldDescription,
+            playersOnField = moveResult.playersOnField
+        )
 
+        // Send to subscribed frontend clients
+        messagingTemplate.convertAndSend("/topic/diceResult/$playerId", dto)
     }
 }

--- a/src/main/kotlin/at/mankomania/server/controller/PlayerController.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/PlayerController.kt
@@ -1,0 +1,52 @@
+package at.mankomania.server.controller
+/**
+ * @file PlayerController.kt
+ * @author eles17
+ * @since 25.4.2025
+ * @description
+ *  PlayerController is responsible for handling player-specific actions such as rolling dice.
+ *  It listens to WebSocket messages and sends back real-time results using messaging topics.
+ *  The controller is designed for extensibility as more player actions (e.g., movement, purchases) are added.
+ */
+import at.mankomania.server.model.Player
+import at.mankomania.server.util.DefaultDiceStrategy
+import at.mankomania.server.util.Dice
+import org.springframework.messaging.handler.annotation.MessageMapping
+import org.springframework.messaging.handler.annotation.Payload
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.stereotype.Controller
+
+
+@Controller
+class PlayerController(private val messagingTemplate: SimpMessagingTemplate) {
+
+    //Uses the default strategy dor generating dice rolls
+    private val dice = Dice(DefaultDiceStrategy())
+    //Temporary player storage; should be replaced by proper session/player management
+    private val players = mutableMapOf<String, Player>()
+
+
+    //temporary mock for testing
+    init{
+        players["blue"] = Player("blue")
+    }
+    @MessageMapping("/rollDice")
+    fun handleDiceRoll(@Payload playerId: String) {
+        val player = players[playerId]
+        if (player == null) {
+            println("Player not found: $playerId")
+            return
+        }
+        //roll dice using strategy
+        val result = dice.roll()
+
+        player.recordDiceRoll(result)
+
+        //log
+        println("Player $playerId rolled Dice: ${result.die1} + ${result.die2} = ${result.sum}")
+
+        //send the result to the player via STOMP
+        messagingTemplate.convertAndSend("/topic/diceResult/$playerId", result)
+
+    }
+}

--- a/src/main/kotlin/at/mankomania/server/controller/dto/DiceMoveResultDto.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/dto/DiceMoveResultDto.kt
@@ -1,0 +1,21 @@
+package at.mankomania.server.controller.dto
+
+/**
+ * @file DiceMoveResultDto.kt
+ * @author eles17
+ * @since 11.5.2025
+ * @description
+ * Combines the result of a Dice roll and resulting move for the player.
+ * Used in WebSocket communication to return all state changes after a roll.
+ */
+
+data class DiceMoveResultDto(
+    val playerId: String,
+    val die1: Int,
+    val die2: Int,
+    val sum: Int,
+    val fieldIndex: Int,
+    val fieldType: String,
+    val fieldDescription: String,
+    val playersOnField: List<String>
+)

--- a/src/main/kotlin/at/mankomania/server/model/Player.kt
+++ b/src/main/kotlin/at/mankomania/server/model/Player.kt
@@ -1,5 +1,7 @@
 package at.mankomania.server.model
 
+import at.mankomania.server.util.DiceResult
+
 /**
  * @author eles17
  * Represents a player in the game.
@@ -10,7 +12,8 @@ package at.mankomania.server.model
 data class Player(
     val name: String,
     var position: Int = 0,
-    var balance: Int = 0
+    var balance: Int = 0,
+    val diceHistory: MutableList<DiceResult> = mutableListOf()
 ) {
     /**
      * Moves the player forward on the board by a given number of steps.
@@ -71,5 +74,13 @@ data class Player(
      */
     fun getCurrentPosition(): Int {
         return position
+    }
+
+    /**
+     * stores the result of each dice roll in diceHistory.
+     * whenever dice is rolled it can be called
+     */
+    fun Player.recordDiceRoll(result: DiceResult) {
+        diceHistory.add(result)
     }
 }

--- a/src/main/kotlin/at/mankomania/server/model/Player.kt
+++ b/src/main/kotlin/at/mankomania/server/model/Player.kt
@@ -13,7 +13,7 @@ data class Player(
     val name: String,
     var position: Int = 0,
     var balance: Int = 0,
-    val diceHistory: MutableList<DiceResult> = mutableListOf()
+    val diceHistory: MutableList<DiceResult> = mutableListOf(),
     var money: MutableMap<Int, Int>? = null
 ) {
     /**
@@ -81,7 +81,7 @@ data class Player(
      * stores the result of each dice roll in diceHistory.
      * whenever dice is rolled it can be called
      */
-    fun Player.recordDiceRoll(result: DiceResult) {
+    fun recordDiceRoll(result: DiceResult) {
         diceHistory.add(result)
     }
 }

--- a/src/main/kotlin/at/mankomania/server/util/DefaultDiceStrategy.kt
+++ b/src/main/kotlin/at/mankomania/server/util/DefaultDiceStrategy.kt
@@ -5,11 +5,11 @@ import kotlin.random.Random
 /**
  * Default dice roll strategy using Random.nextInt() to simulate rolling two dice.
  */
-// concrete implementation, this is a normal dice
 class DefaultDiceStrategy : DiceStrategy {
     override fun roll(): DiceResult {
         val die1 = Random.nextInt(1, 7) // Rolls between 1 and 6
         val die2 = Random.nextInt(1, 7) // Rolls between 1 and 6
+        // concrete implementation, this is a normal dice
         return DiceResult(die1, die2) //return separate values for each die
     }
 }

--- a/src/main/kotlin/at/mankomania/server/util/DefaultDiceStrategy.kt
+++ b/src/main/kotlin/at/mankomania/server/util/DefaultDiceStrategy.kt
@@ -5,10 +5,11 @@ import kotlin.random.Random
 /**
  * Default dice roll strategy using Random.nextInt() to simulate rolling two dice.
  */
+// concrete implementation, this is a normal dice
 class DefaultDiceStrategy : DiceStrategy {
     override fun roll(): DiceResult {
         val die1 = Random.nextInt(1, 7) // Rolls between 1 and 6
         val die2 = Random.nextInt(1, 7) // Rolls between 1 and 6
-        return DiceResult(die1, die2, die1 + die2) //return separate values for each die
+        return DiceResult(die1, die2) //return separate values for each die
     }
 }

--- a/src/main/kotlin/at/mankomania/server/util/DefaultDiceStrategy.kt
+++ b/src/main/kotlin/at/mankomania/server/util/DefaultDiceStrategy.kt
@@ -1,19 +1,14 @@
-/**
- * @file DefaultDiceStrategy.kt
- * @author eles17
- * @since
- * @description responsible for rolling dice, delegating the actual roll logic to a strategy.
- */
 package at.mankomania.server.util
 
 import kotlin.random.Random
+
 /**
  * Default dice roll strategy using Random.nextInt() to simulate rolling two dice.
  */
 class DefaultDiceStrategy : DiceStrategy {
-    override fun roll(): Int{
-        val die1 = Random.nextInt(1,7) //Rolls between 1 and 6
-        val die2 = Random.nextInt(1,7) //Rolls between 1 and 6
-        return die1 + die2
+    override fun roll(): DiceResult {
+        val die1 = Random.nextInt(1, 7) // Rolls between 1 and 6
+        val die2 = Random.nextInt(1, 7) // Rolls between 1 and 6
+        return DiceResult(die1, die2, die1 + die2) //return separate values for each die
     }
 }

--- a/src/main/kotlin/at/mankomania/server/util/Dice.kt
+++ b/src/main/kotlin/at/mankomania/server/util/Dice.kt
@@ -2,11 +2,12 @@
  * @file Dice.kt
  * @author eles17
  * @since 7.4.2025
- * @description resposible for rolling dice, delegating the catual roll logic to a strategy
+ * @description responsible for rolling dice by delegating actual roll logic to a strategy
  */
 package at.mankomania.server.util
 
-//this is a dice roller/ wrapper. It delegates the roll
+// this is a dice roller/ wrapper. It delegates the roll
+
 class Dice(private val strategy: DiceStrategy) {
     /**
      * Rolls the dice using the provided strategy.

--- a/src/main/kotlin/at/mankomania/server/util/Dice.kt
+++ b/src/main/kotlin/at/mankomania/server/util/Dice.kt
@@ -1,20 +1,17 @@
 /**
  * @file Dice.kt
  * @author eles17
- * @since
- * @description responsible for rolling dice, delegating the actual roll logic to a strategy
+ * @since 7.4.2025
+ * @description resposible for rolling dice, delegating the catual roll logic to a strategy
  */
 package at.mankomania.server.util
 
-/**
- * The Dice class is responsible for rolling dice, delegating the actual roll logic to a strategy.
- */
+
 class Dice(private val strategy: DiceStrategy) {
     /**
      * Rolls the dice using the provided strategy.
      *
      * @return The result of the dice roll according to the strategy.
      */
-    fun roll(): Int = strategy.roll()
-
+    fun roll(): DiceResult = strategy.roll()
 }

--- a/src/main/kotlin/at/mankomania/server/util/Dice.kt
+++ b/src/main/kotlin/at/mankomania/server/util/Dice.kt
@@ -6,7 +6,7 @@
  */
 package at.mankomania.server.util
 
-
+//this is a dice roller/ wrapper. It delegates the roll
 class Dice(private val strategy: DiceStrategy) {
     /**
      * Rolls the dice using the provided strategy.

--- a/src/main/kotlin/at/mankomania/server/util/DiceResult.kt
+++ b/src/main/kotlin/at/mankomania/server/util/DiceResult.kt
@@ -1,4 +1,6 @@
 package at.mankomania.server.util
-
-data class DiceResult(val die1: Int, val die2: Int, val sum: Int)
-
+// this is a data holder. It stors and transports the result of a roll
+//both dice and their sum
+data class DiceResult(val die1: Int, val die2: Int) {
+    val sum: Int get() = die1 + die2
+}

--- a/src/main/kotlin/at/mankomania/server/util/DiceResult.kt
+++ b/src/main/kotlin/at/mankomania/server/util/DiceResult.kt
@@ -1,0 +1,4 @@
+package at.mankomania.server.util
+
+data class DiceResult(val die1: Int, val die2: Int, val sum: Int)
+

--- a/src/main/kotlin/at/mankomania/server/util/DiceStrategy.kt
+++ b/src/main/kotlin/at/mankomania/server/util/DiceStrategy.kt
@@ -15,5 +15,5 @@ fun interface DiceStrategy {
      * Rolls the dice and returns the result.
      * @return The result of the dice roll.
      */
-    fun roll(): Int
+    fun roll(): DiceResult
 }

--- a/src/main/kotlin/at/mankomania/server/util/DiceStrategy.kt
+++ b/src/main/kotlin/at/mankomania/server/util/DiceStrategy.kt
@@ -8,12 +8,13 @@ package at.mankomania.server.util
 
 /**
  * Functional Interface for interchangeable dice rolling strategies.
- * The strategy defines how the dice are rolled.
+ * The strategy defines how the dice are rolled and returns the result containing both dice and their sum.
  */
+// Defines a contract, what a dice strategy must do, without saying how
 fun interface DiceStrategy {
     /**
      * Rolls the dice and returns the result.
-     * @return The result of the dice roll.
+     * @return The result of the dice roll containing both dice and their sum.
      */
     fun roll(): DiceResult
 }

--- a/src/test/kotlin/at/mankomania/server/DiceTest.kt
+++ b/src/test/kotlin/at/mankomania/server/DiceTest.kt
@@ -18,10 +18,13 @@ class DiceTest {
      */
     @Test
     fun testRollDiceReturnsValidValue(){
-        val dice = Dice(DefaultDiceStrategy()) // HAS PARAMETER NOW CHECK :...
+        val dice = Dice(DefaultDiceStrategy())
         repeat(100){
             val result = dice.roll()
-            assertTrue("Dice roll should be between 2 and 12, got $result", result in 2..12)
+            assertTrue("Die 1 should be between 1 and 6, got ${result.die1}", result.die1 in 1..6)
+            assertTrue("Die 2 should be between 1 and 6, got ${result.die2}", result.die2 in 1..6)
+            assertTrue("Sum should equal die 1 + die 2, got ${result.sum}", result.sum == result.die1 + result.die2)
+            assertTrue("Sum should be between 2 and 12, got ${result.sum}", result.sum in 2..12)
         }
     }
 }

--- a/src/test/kotlin/at/mankomania/server/PlayerTest.kt
+++ b/src/test/kotlin/at/mankomania/server/PlayerTest.kt
@@ -150,4 +150,17 @@ class PlayerTest {
         player.position = 22
         assertEquals(22, player.getCurrentPosition())
     }
+
+
+    /**
+     * Verifies that the dice roll result is correctly stored in the player's history.
+     */
+    @Test
+    fun recordDiceRollStoresResult() {
+        val result = at.mankomania.server.util.DiceResult(2, 5)
+        player.recordDiceRoll(result)
+
+        assertEquals(1, player.diceHistory.size)
+        assertEquals(result, player.diceHistory.first())
+    }
 }

--- a/src/test/kotlin/at/mankomania/server/controller/PlayerControllerTest.kt
+++ b/src/test/kotlin/at/mankomania/server/controller/PlayerControllerTest.kt
@@ -1,0 +1,62 @@
+package at.mankomania.server.controller
+
+/**
+ * @file PlayerControllerTest.kt
+ * @author eles17
+ * @since 03.05.2025
+ * @description
+ * Unit test class for verifying the behavior of [PlayerController].
+ *
+ * This test focuses on the WebSocket-based dice rolling functionality.
+ * It ensures that when a player requests to roll dice:
+ * - A valid DiceResult is generated.
+ * - The result is sent to the correct WebSocket topic.
+ * - The result contains valid die values and the correct sum.
+ *
+ * The class uses a mocked [SimpMessagingTemplate] to simulate message broadcasting without needing an active WebSocket server.
+ */
+
+import at.mankomania.server.util.DiceResult
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import kotlin.test.assertEquals
+
+
+class PlayerControllerTest {
+
+    private lateinit var messagingTemplate: org.springframework.messaging.simp.SimpMessagingTemplate
+    private lateinit var controller: PlayerController
+
+    @BeforeEach
+    fun setup() {
+        messagingTemplate = mock()
+        controller = PlayerController(messagingTemplate)
+    }
+
+    /**
+     * Unit test for verifying the handleDiceRoll WebSocket method in PlayerController.
+     * Ensures valid messaging behavior and result correctness.
+     */
+    @Test
+    fun handleDiceRoll_sendsValidResultToCorrectWebSocketTopic(){
+        val playerId = "blue"
+
+        controller.handleDiceRoll(playerId)
+
+        val topicCaptor = ArgumentCaptor.forClass(String::class.java)
+        val resultCaptor = ArgumentCaptor.forClass(at.mankomania.server.util.DiceResult::class.java)
+
+        verify(messagingTemplate).convertAndSend(topicCaptor.capture(), resultCaptor.capture())
+
+        val sentTopic = topicCaptor.value
+        val result = resultCaptor.value
+
+        assertEquals("/topic/diceResult/$playerId", sentTopic)
+        assert(result.die1 in 1..6)
+        assert(result.die2 in 1..6)
+        assertEquals(result.die1 + result.die2, result.sum)
+    }
+}

--- a/src/test/kotlin/at/mankomania/server/controller/PlayerControllerTest.kt
+++ b/src/test/kotlin/at/mankomania/server/controller/PlayerControllerTest.kt
@@ -62,7 +62,7 @@ class PlayerControllerTest {
         diceField.set(controller, Dice { diceResult })
 
         // Act
-        controller.handleDiceRoll(playerId)
+        controller.handleDiceRoll("default", playerId)
 
         // Assert
         val topicCaptor = ArgumentCaptor.forClass(String::class.java)
@@ -90,7 +90,7 @@ class PlayerControllerTest {
         `when`(sessionManager.getGameController("default")).thenReturn(null)
 
         // Act
-        controller.handleDiceRoll("player1")
+        controller.handleDiceRoll("default", "player1")
 
         // Assert: no messages at all
         verifyNoInteractions(messagingTemplate)
@@ -113,7 +113,7 @@ class PlayerControllerTest {
         diceField.set(controller, Dice { diceResult })
 
         // Act
-        controller.handleDiceRoll(playerId)
+        controller.handleDiceRoll("default", playerId)
 
         // Assert: no messages at all
         verifyNoInteractions(messagingTemplate)

--- a/src/test/kotlin/at/mankomania/server/controller/PlayerControllerTest.kt
+++ b/src/test/kotlin/at/mankomania/server/controller/PlayerControllerTest.kt
@@ -3,60 +3,119 @@ package at.mankomania.server.controller
 /**
  * @file PlayerControllerTest.kt
  * @author eles17
- * @since 03.05.2025
+ * @since 11.5.2025
  * @description
- * Unit test class for verifying the behavior of [PlayerController].
- *
- * This test focuses on the WebSocket-based dice rolling functionality.
- * It ensures that when a player requests to roll dice:
- * - A valid DiceResult is generated.
- * - The result is sent to the correct WebSocket topic.
- * - The result contains valid die values and the correct sum.
- *
- * The class uses a mocked [SimpMessagingTemplate] to simulate message broadcasting without needing an active WebSocket server.
+ * Unit tests for PlayerController's handleDiceRoll method, verifying correct WebSocket messaging behavior.
  */
 
+import at.mankomania.server.controller.dto.DiceMoveResultDto
+import at.mankomania.server.controller.GameController
+import at.mankomania.server.manager.GameSessionManager
+import at.mankomania.server.model.MoveResult
+import at.mankomania.server.util.Dice
 import at.mankomania.server.util.DiceResult
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.mockito.ArgumentCaptor
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.verify
-import kotlin.test.assertEquals
-
+import org.mockito.Mockito.*
+import org.springframework.messaging.simp.SimpMessagingTemplate
 
 class PlayerControllerTest {
 
-    private lateinit var messagingTemplate: org.springframework.messaging.simp.SimpMessagingTemplate
+    private lateinit var messagingTemplate: SimpMessagingTemplate
+    private lateinit var sessionManager: GameSessionManager
     private lateinit var controller: PlayerController
 
+    /**
+     * Initializes mocks and the PlayerController before each test.
+     */
     @BeforeEach
-    fun setup() {
-        messagingTemplate = mock()
-        controller = PlayerController(messagingTemplate)
+    fun setUp() {
+        messagingTemplate = mock(SimpMessagingTemplate::class.java)
+        sessionManager = mock(GameSessionManager::class.java)
+        controller = PlayerController(messagingTemplate, sessionManager)
     }
 
     /**
-     * Unit test for verifying the handleDiceRoll WebSocket method in PlayerController.
-     * Ensures valid messaging behavior and result correctness.
+     * Happy path: when computeMoveResult returns non-null, a DiceMoveResultDto should be sent to the correct topic.
      */
     @Test
-    fun handleDiceRoll_sendsValidResultToCorrectWebSocketTopic(){
-        val playerId = "blue"
+    fun `handleDiceRoll sends correct result when moveResult is non-null`() {
+        // Arrange
+        val playerId = "player1"
+        val diceResult = DiceResult(die1 = 2, die2 = 3)
+        val expectedResult = MoveResult(
+            newPosition = 10,
+            oldPosition = 7,
+            fieldType = "NORMAL",
+            fieldDescription = "Sample Field",
+            playersOnField = listOf(playerId)
+        )
+        val gameController = mock(GameController::class.java)
+        `when`(sessionManager.getGameController("default")).thenReturn(gameController)
+        `when`(gameController.computeMoveResult(playerId, diceResult.sum)).thenReturn(expectedResult)
 
+        // Inject deterministic dice
+        val diceField = PlayerController::class.java.getDeclaredField("dice")
+        diceField.isAccessible = true
+        diceField.set(controller, Dice { diceResult })
+
+        // Act
         controller.handleDiceRoll(playerId)
 
+        // Assert
         val topicCaptor = ArgumentCaptor.forClass(String::class.java)
-        val resultCaptor = ArgumentCaptor.forClass(at.mankomania.server.util.DiceResult::class.java)
+        val dtoCaptor = ArgumentCaptor.forClass(DiceMoveResultDto::class.java)
+        verify(messagingTemplate).convertAndSend(topicCaptor.capture(), dtoCaptor.capture())
 
-        verify(messagingTemplate).convertAndSend(topicCaptor.capture(), resultCaptor.capture())
+        assertEquals("/topic/diceResult/$playerId", topicCaptor.value)
+        val dto = dtoCaptor.value
+        assertEquals(playerId, dto.playerId)
+        assertEquals(2, dto.die1)
+        assertEquals(3, dto.die2)
+        assertEquals(5, dto.sum)
+        assertEquals(expectedResult.newPosition, dto.fieldIndex)
+        assertEquals(expectedResult.fieldType, dto.fieldType)
+        assertEquals(expectedResult.fieldDescription, dto.fieldDescription)
+        assertEquals(expectedResult.playersOnField, dto.playersOnField)
+    }
 
-        val sentTopic = topicCaptor.value
-        val result = resultCaptor.value
+    /**
+     * When no GameController is found for the default game, no message should be sent.
+     */
+    @Test
+    fun `handleDiceRoll returns early when gameController is null`() {
+        // Arrange
+        `when`(sessionManager.getGameController("default")).thenReturn(null)
 
-        assertEquals("/topic/diceResult/$playerId", sentTopic)
-        assert(result.die1 in 1..6)
-        assert(result.die2 in 1..6)
-        assertEquals(result.die1 + result.die2, result.sum)
+        // Act
+        controller.handleDiceRoll("player1")
+
+        // Assert: no messages at all
+        verifyNoInteractions(messagingTemplate)
+    }
+    /**
+     * When computeMoveResult returns null (move failed), no message should be sent.
+     */
+    @Test
+    fun `handleDiceRoll returns early when moveResult is null`() {
+        // Arrange
+        val playerId = "player1"
+        val diceResult = DiceResult(die1 = 4, die2 = 5)
+        val gameController = mock(GameController::class.java)
+        `when`(sessionManager.getGameController("default")).thenReturn(gameController)
+        `when`(gameController.computeMoveResult(playerId, diceResult.sum)).thenReturn(null)
+
+        // Inject deterministic dice
+        val diceField = PlayerController::class.java.getDeclaredField("dice")
+        diceField.isAccessible = true
+        diceField.set(controller, Dice { diceResult })
+
+        // Act
+        controller.handleDiceRoll(playerId)
+
+        // Assert: no messages at all
+        verifyNoInteractions(messagingTemplate)
     }
 }


### PR DESCRIPTION
This update adds a new WebSocket/STOMP endpoint at /app/rollDice. When the client sends its player ID there, the server:
	1.	Uses a secure, strategy-based dice roller to generate two random values (1–6).
	2.	Passes the total to the game logic to compute the resulting move.

If a valid game session is found and the move succeeds, the server packages:
	•	die1 and die2 (the individual rolls)
	•	sum (their total)
	•	fieldIndex (the new board position)
	•	fieldType and fieldDescription (what kind of cell was landed on)
	•	playersOnField (other players currently on that cell)

…into a single DiceMoveResultDto, and broadcasts it to /topic/diceResult/{playerId}. The client then has everything it needs—in one message—to animate the dice, update the board, and show the field details.

If no game session exists or the move calculation returns null, the controller simply returns without sending anything. Comprehensive unit tests cover both the happy path and these early-exit cases, ensuring reliable, predictable behavior.