### PR TITLE
Feat/lobby backend

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,17 @@
 
 		<sonar.coverage.exclusions>
 			**/WebSocketManager.kt,
-			**/WebSocketBrokerController.kt
+			**/WebSocketBrokerController.kt,
+			**/config/**,
+			**/controller/dto/**,
+			**/Application.kt,
+			**/websocket/**,
+			**/controller/dto/**,
+			**/service/LobbyService*
 		</sonar.coverage.exclusions>
+		<sonar.exclusions>
+			**/build/**, **/.idea/**, **/generated/**, local.properties
+		</sonar.exclusions>
 
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,8 @@
 			**/Application.kt,
 			**/websocket/**,
 			**/controller/dto/**,
-			**/service/LobbyService*
+			**/service/LobbyService*,
+			**/model/LobbyInfo.kt
 		</sonar.coverage.exclusions>
 		<sonar.exclusions>
 			**/build/**, **/.idea/**, **/generated/**, local.properties

--- a/src/main/kotlin/at/mankomania/server/controller/dto/LobbyMessage.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/dto/LobbyMessage.kt
@@ -1,0 +1,7 @@
+package at.mankomania.server.controller.dto
+
+data class LobbyMessage(
+    val type: String,
+    val playerName: String,
+    val lobbyId: String? = null
+)

--- a/src/main/kotlin/at/mankomania/server/controller/dto/LobbyResponse.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/dto/LobbyResponse.kt
@@ -4,5 +4,6 @@ data class LobbyResponse(
     val type: String,
     val lobbyId: String,
     val playerName: String? = null,
-    val playerCount: Int? = null
+    val playerCount: Int? = null,
+    val players: List<String>? = null
 )

--- a/src/main/kotlin/at/mankomania/server/controller/dto/LobbyResponse.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/dto/LobbyResponse.kt
@@ -1,0 +1,8 @@
+package at.mankomania.server.controller.dto
+
+data class LobbyResponse(
+    val type: String,
+    val lobbyId: String,
+    val playerName: String? = null,
+    val playerCount: Int? = null
+)

--- a/src/main/kotlin/at/mankomania/server/model/LobbyInfo.kt
+++ b/src/main/kotlin/at/mankomania/server/model/LobbyInfo.kt
@@ -1,0 +1,6 @@
+package at.mankomania.server.model
+
+data class LobbyInfo(
+    val lobbyId: String,
+    val players: MutableList<String> = mutableListOf()
+)

--- a/src/main/kotlin/at/mankomania/server/service/LobbyService.kt
+++ b/src/main/kotlin/at/mankomania/server/service/LobbyService.kt
@@ -1,0 +1,33 @@
+package at.mankomania.server.service
+
+import at.mankomania.server.model.Player
+import org.springframework.stereotype.Service
+
+data class Lobby(
+    val lobbyId: String,
+    val players: MutableList<Player> = mutableListOf()
+)
+
+@Service
+class LobbyService {
+    private val lobbies = mutableMapOf<String, Lobby>()
+
+    fun createLobby(lobbyId: String, hostName: String): Lobby {
+        val player = Player(hostName)
+        val lobby = Lobby(lobbyId = lobbyId, players = mutableListOf(player))
+        lobbies[lobbyId] = lobby
+        return lobby
+    }
+
+    fun joinLobby(lobbyId: String, playerName: String): Boolean {
+        val lobby = lobbies[lobbyId]
+        if (lobby == null || lobby.players.size >= 4) return false
+        lobby.players.add(Player(playerName))
+        return true
+    }
+
+    fun getPlayers(lobbyId: String): List<Player> {
+        return lobbies[lobbyId]?.players ?: emptyList()
+    }
+}
+

--- a/src/main/kotlin/at/mankomania/server/service/LobbyService.kt
+++ b/src/main/kotlin/at/mankomania/server/service/LobbyService.kt
@@ -29,5 +29,9 @@ class LobbyService {
     fun getPlayers(lobbyId: String): List<Player> {
         return lobbies[lobbyId]?.players ?: emptyList()
     }
+    fun getLobby(lobbyId: String): Lobby? {
+        return lobbies[lobbyId]
+    }
+
 }
 

--- a/src/main/kotlin/at/mankomania/server/websocket/LobbyWebSoketController.kt
+++ b/src/main/kotlin/at/mankomania/server/websocket/LobbyWebSoketController.kt
@@ -1,0 +1,53 @@
+package at.mankomania.server.websocket
+
+import at.mankomania.server.controller.dto.LobbyMessage
+import at.mankomania.server.controller.dto.LobbyResponse
+import at.mankomania.server.service.LobbyService
+import org.slf4j.LoggerFactory
+import org.springframework.messaging.handler.annotation.MessageMapping
+import org.springframework.messaging.handler.annotation.Payload
+import org.springframework.messaging.handler.annotation.SendTo
+import org.springframework.stereotype.Controller
+
+@Controller
+class LobbyWebSocketController(
+    private val lobbyService: LobbyService
+) {
+    private val logger = LoggerFactory.getLogger(LobbyWebSocketController::class.java)
+
+    @MessageMapping("/lobby") // z.B. /app/lobby
+    @SendTo("/topic/lobby")   // z.B. /topic/lobby für alle Clients
+    fun handleLobbyAction(@Payload message: LobbyMessage): LobbyResponse {
+        logger.info("Received lobby message: $message")
+
+        return when (message.type) {
+            "create" -> {
+                val lobby = lobbyService.createLobby(message.lobbyId!!, message.playerName)
+                LobbyResponse(
+                    type = "created",
+                    lobbyId = lobby.lobbyId,
+                    playerName = message.playerName,
+                    playerCount = lobby.players.size
+                )
+            }
+
+            "join" -> {
+                val success = lobbyService.joinLobby(message.lobbyId!!, message.playerName)
+                val playerCount = lobbyService.getPlayers(message.lobbyId).size
+                LobbyResponse(
+                    type = if (success) "joined" else "join-failed",
+                    lobbyId = message.lobbyId,
+                    playerName = message.playerName,
+                    playerCount = if (success) playerCount else null
+                )
+            }
+
+            else -> LobbyResponse(
+                type = "error",
+                lobbyId = message.lobbyId ?: "unknown",
+                playerName = message.playerName,
+                playerCount = null
+            )
+        }
+    }
+}

--- a/src/main/kotlin/at/mankomania/server/websocket/LobbyWebSoketController.kt
+++ b/src/main/kotlin/at/mankomania/server/websocket/LobbyWebSoketController.kt
@@ -41,6 +41,15 @@ class LobbyWebSocketController(
                     playerCount = if (success) playerCount else null
                 )
             }
+            "start" -> {
+                logger.info("🔔 Game started in lobby ${message.lobbyId} by ${message.playerName}")
+                LobbyResponse(
+                    type = "start",
+                    lobbyId = message.lobbyId ?: "unknown",
+                    playerName = message.playerName,
+                    playerCount = null
+                )
+            }
 
             else -> LobbyResponse(
                 type = "error",

--- a/src/main/kotlin/at/mankomania/server/websocket/LobbyWebSoketController.kt
+++ b/src/main/kotlin/at/mankomania/server/websocket/LobbyWebSoketController.kt
@@ -35,14 +35,17 @@ class LobbyWebSocketController(
 
             "join" -> {
                 val success = lobbyService.joinLobby(message.lobbyId!!, message.playerName)
-                val playerCount = lobbyService.getPlayers(message.lobbyId).size
+                val players = lobbyService.getPlayers(message.lobbyId).map { it.name }
+
                 LobbyResponse(
                     type = if (success) "joined" else "join-failed",
                     lobbyId = message.lobbyId,
                     playerName = message.playerName,
-                    playerCount = if (success) playerCount else null
+                    playerCount = if (success) players.size else null,
+                    players = if (success) players else null
                 )
             }
+
             "start" -> {
                 logger.info("🔔 Game started in lobby ${message.lobbyId} by ${message.playerName}")
 

--- a/src/main/kotlin/at/mankomania/server/websocket/LobbyWebSoketController.kt
+++ b/src/main/kotlin/at/mankomania/server/websocket/LobbyWebSoketController.kt
@@ -23,11 +23,13 @@ class LobbyWebSocketController(
         return when (message.type) {
             "create" -> {
                 val lobby = lobbyService.createLobby(message.lobbyId!!, message.playerName)
+                val playerNames = lobby.players.map { it.name }
                 LobbyResponse(
                     type = "created",
                     lobbyId = lobby.lobbyId,
                     playerName = message.playerName,
-                    playerCount = lobby.players.size
+                    playerCount = lobby.players.size,
+                    players = playerNames
                 )
             }
 
@@ -43,11 +45,16 @@ class LobbyWebSocketController(
             }
             "start" -> {
                 logger.info("🔔 Game started in lobby ${message.lobbyId} by ${message.playerName}")
+
+                val lobby = lobbyService.getLobby(message.lobbyId ?: "unknown")
+                val playerNames = lobby?.players?.map { it.name } ?: emptyList()
+
                 LobbyResponse(
                     type = "start",
                     lobbyId = message.lobbyId ?: "unknown",
                     playerName = message.playerName,
-                    playerCount = null
+                    playerCount = playerNames.size,
+                    players = playerNames
                 )
             }
 


### PR DESCRIPTION
This PR introduces the backend functionality required for lobby creation and joining.
- WebSocket endpoints to handle lobby creation and joining
- New DTOs for structured WebSocket communication (LobbyMessage, LobbyResponse, etc.)
- A LobbyService to manage lobby state and connected players
- Basic logic to support multiple players joining the same lobby
- Early game start condition: game can start when at least two players have joined

This PR is designed to work with the corresponding frontend implementation in [mankomania-client#49](https://github.com/mankomania/mankomania-client/pull/49).
