### PR TITLE
fix: prevent double joining

### DIFF
--- a/src/main/kotlin/at/mankomania/server/service/LobbyService.kt
+++ b/src/main/kotlin/at/mankomania/server/service/LobbyService.kt
@@ -22,6 +22,10 @@ class LobbyService {
     fun joinLobby(lobbyId: String, playerName: String): Boolean {
         val lobby = lobbies[lobbyId]
         if (lobby == null || lobby.players.size >= 4) return false
+        if (lobby.players.any { it.name == playerName }) {
+            println("🔁 Spieler '$playerName' ist bereits in Lobby '$lobbyId' – wird ignoriert.")
+            return true
+        }
         lobby.players.add(Player(playerName))
         return true
     }


### PR DESCRIPTION
This PR improves the robustness of the lobby join logic on the server.
It ensures that a player cannot be added to the same lobby multiple times by checking for existing names.

This PR correlates with Client PR # 54
https://github.com/mankomania/mankomania-client/pull/54