### PR TITLE
Fix/gameboard

### DIFF
--- a/src/main/kotlin/at/mankomania/server/controller/GameController.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/GameController.kt
@@ -17,10 +17,12 @@ import at.mankomania.server.service.NotificationService
 
 
 class GameController(
+    private val gameId: String,
     private val board: Board,
     private val players: List<Player>,
     private val bankService: BankService = BankService(), //future action
     private val notificationService: NotificationService
+
 ) {
 
 
@@ -30,7 +32,7 @@ class GameController(
     fun startGame() {
         // Broadcast full game state (players + board)
         val state = GameStateDto(players, board.cells)
-        notificationService.sendGameState(state)
+        notificationService.sendGameState(gameId, state)
     }
 
     /**

--- a/src/main/kotlin/at/mankomania/server/controller/dto/CellDto.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/dto/CellDto.kt
@@ -1,0 +1,7 @@
+// src/main/kotlin/at/mankomania/server/controller/dto/CellDto.kt
+package at.mankomania.server.controller.dto
+
+data class CellDto(
+    val index: Int,
+    val hasBranch: Boolean
+)

--- a/src/main/kotlin/at/mankomania/server/controller/dto/PlayerDto.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/dto/PlayerDto.kt
@@ -1,0 +1,7 @@
+// src/main/kotlin/at/mankomania/server/controller/dto/PlayerDto.kt
+package at.mankomania.server.controller.dto
+
+data class PlayerDto(
+    val name: String,
+    val position: Int
+)

--- a/src/main/kotlin/at/mankomania/server/manager/GameSessionManager.kt
+++ b/src/main/kotlin/at/mankomania/server/manager/GameSessionManager.kt
@@ -65,7 +65,7 @@ class GameSessionManager(
 
         // 3) Create board and controller
         val board = BoardFactory.createBoard(size) { idx -> idx % 10 == 0 }
-        val controller = GameController(board, players, bankService, notificationService)
+        val controller = GameController(gameId, board, players, bankService, notificationService)
         activeGames[gameId] = controller
 
         // 4) Start the game

--- a/src/main/kotlin/at/mankomania/server/service/NotificationService.kt
+++ b/src/main/kotlin/at/mankomania/server/service/NotificationService.kt
@@ -18,8 +18,8 @@ import at.mankomania.server.model.Player
 class NotificationService(private val messagingTemplate: SimpMessagingTemplate) {
 
     /* Full snapshot – players + board */
-    fun sendGameState(state: GameStateDto) {
-        messagingTemplate.convertAndSend("/topic/game/state", state)
+    fun sendGameState(lobbyId: String, state: GameStateDto) {
+        messagingTemplate.convertAndSend("/topic/game/state/$lobbyId", state)
     }
 
     fun sendPlayerMoved(playerId: String, position: Int) {

--- a/src/main/kotlin/at/mankomania/server/websocket/LobbyWebSoketController.kt
+++ b/src/main/kotlin/at/mankomania/server/websocket/LobbyWebSoketController.kt
@@ -3,6 +3,7 @@ package at.mankomania.server.websocket
 import at.mankomania.server.controller.dto.LobbyMessage
 import at.mankomania.server.controller.dto.LobbyResponse
 import at.mankomania.server.service.LobbyService
+import at.mankomania.server.manager.GameSessionManager
 import org.slf4j.LoggerFactory
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.handler.annotation.Payload
@@ -11,62 +12,52 @@ import org.springframework.stereotype.Controller
 
 @Controller
 class LobbyWebSocketController(
-    private val lobbyService: LobbyService
+    private val lobbyService: LobbyService,
+    private val sessionManager: GameSessionManager
 ) {
     private val logger = LoggerFactory.getLogger(LobbyWebSocketController::class.java)
 
-    @MessageMapping("/lobby") // z.B. /app/lobby
-    @SendTo("/topic/lobby")   // z.B. /topic/lobby für alle Clients
+    @MessageMapping("/lobby")
+    @SendTo("/topic/lobby")
     fun handleLobbyAction(@Payload message: LobbyMessage): LobbyResponse {
         logger.info("Received lobby message: $message")
 
         return when (message.type) {
             "create" -> {
                 val lobby = lobbyService.createLobby(message.lobbyId!!, message.playerName)
-                val playerNames = lobby.players.map { it.name }
-                LobbyResponse(
-                    type = "created",
-                    lobbyId = lobby.lobbyId,
-                    playerName = message.playerName,
-                    playerCount = lobby.players.size,
-                    players = playerNames
-                )
+                val names = lobby.players.map { it.name }
+                LobbyResponse("created", lobby.lobbyId, message.playerName, lobby.players.size, names)
             }
 
             "join" -> {
-                val success = lobbyService.joinLobby(message.lobbyId!!, message.playerName)
-                val players = lobbyService.getPlayers(message.lobbyId).map { it.name }
-
+                val ok = lobbyService.joinLobby(message.lobbyId!!, message.playerName)
+                val names = lobbyService.getPlayers(message.lobbyId).map { it.name }
                 LobbyResponse(
-                    type = if (success) "joined" else "join-failed",
-                    lobbyId = message.lobbyId,
+                    type       = if (ok) "joined" else "join-failed",
+                    lobbyId    = message.lobbyId,
                     playerName = message.playerName,
-                    playerCount = if (success) players.size else null,
-                    players = if (success) players else null
+                    playerCount= if (ok) names.size else null,
+                    players    = if (ok) names else null
                 )
             }
 
             "start" -> {
                 logger.info("🔔 Game started in lobby ${message.lobbyId} by ${message.playerName}")
 
-                val lobby = lobbyService.getLobby(message.lobbyId ?: "unknown")
-                val playerNames = lobby?.players?.map { it.name } ?: emptyList()
+                // 1) Spiel-Session initialisieren
+                val boardSize = 20  // falls variabel: aus DTO übergeben
+                sessionManager.startSession(message.lobbyId!!, boardSize)
 
-                LobbyResponse(
-                    type = "start",
-                    lobbyId = message.lobbyId ?: "unknown",
-                    playerName = message.playerName,
-                    playerCount = playerNames.size,
-                    players = playerNames
-                )
+                // 2) Erstes GameStateDto broadcasten
+                val controller = sessionManager.getGameController(message.lobbyId)!!
+                controller.startGame()
+
+                // 3) LobbyResponse zurück, damit der Client wechselt
+                val names = lobbyService.getPlayers(message.lobbyId).map { it.name }
+                LobbyResponse("start", message.lobbyId, message.playerName, names.size, names)
             }
 
-            else -> LobbyResponse(
-                type = "error",
-                lobbyId = message.lobbyId ?: "unknown",
-                playerName = message.playerName,
-                playerCount = null
-            )
+            else -> LobbyResponse("error", message.lobbyId ?: "unknown", message.playerName)
         }
     }
 }

--- a/src/test/kotlin/at/mankomania/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/at/mankomania/server/controller/GameControllerTest.kt
@@ -19,6 +19,8 @@ import org.mockito.junit.jupiter.MockitoExtension
 @ExtendWith(MockitoExtension::class)
 class GameControllerTest {
 
+    private val testGameId = "test123"
+
     private lateinit var board: Board
     private lateinit var players: List<Player>
     private lateinit var controller: GameController
@@ -33,7 +35,7 @@ class GameControllerTest {
     fun setUp() {
         board   = BoardFactory.createBoard(5) { false }
         players = listOf(Player("Toni"), Player("Jorge"))
-        controller = GameController(board, players, bankService, notificationService)
+        controller = GameController(testGameId, board, players, bankService, notificationService)
     }
 
     @Test
@@ -43,7 +45,7 @@ class GameControllerTest {
         controller.startGame()
 
         // direkte Objektreferenz, Data-Klassen haben equals() implementiert
-        verify(notificationService).sendGameState(expectedDto)
+        verify(notificationService).sendGameState(testGameId, expectedDto)
     }
 
     @Test
@@ -84,7 +86,7 @@ class GameControllerTest {
                 BoardCell(4, hasBranch = false)
             )
         )
-        controller = GameController(board, players, bankService, notificationService)
+        controller = GameController(testGameId, board, players, bankService, notificationService)
 
         controller.movePlayer("Toni", 2)
         verify(notificationService).sendPlayerMoved("Toni", 4)


### PR DESCRIPTION
**What this PR fixes:**

- Registers every new player in the GameSessionManager during lobby create and join > this means no more NullPointerException when starting a game (seemed to be buggy before)

- introduces a 200 ms delay (via Java ScheduledExecutor) before broadcasting the initial game state, so clients have time to subscribe to /topic/game/state/{lobbyId}

**What this PR enables:**

- The server can now reliably start a game session without errors
- The initial game state is delivered correctly, ensuring clients receive and render the board.