### PR TITLE
Feature/gameboard improve

### DIFF
--- a/src/main/kotlin/at/mankomania/server/manager/GameSessionManager.kt
+++ b/src/main/kotlin/at/mankomania/server/manager/GameSessionManager.kt
@@ -64,7 +64,7 @@ class GameSessionManager(
         players.forEachIndexed { idx, player -> player.position = startPositions[idx] }
 
         // 3) Create board and controller
-        val board = BoardFactory.createBoard(size) { idx -> idx % 10 == 0 }
+        val board = BoardFactory.createSimpleBoard()
         val controller = GameController(gameId, board, players, bankService, notificationService)
         activeGames[gameId] = controller
 

--- a/src/main/kotlin/at/mankomania/server/model/BoardCell.kt
+++ b/src/main/kotlin/at/mankomania/server/model/BoardCell.kt
@@ -21,7 +21,9 @@ data class BoardCell(
     var state: CellState = CellState.FREE,
     val hasBranch: Boolean,
     val branchOptions: List<Int> = emptyList(),
-    var action: CellAction? = null
+    var action: CellAction? = null,
+    val isLottery: Boolean = false,
+    val isMinigame: Boolean = false
 ) {
     /**
      * Handles a player landing on the cell.

--- a/src/main/kotlin/at/mankomania/server/model/BoardCell.kt
+++ b/src/main/kotlin/at/mankomania/server/model/BoardCell.kt
@@ -22,8 +22,7 @@ data class BoardCell(
     val hasBranch: Boolean,
     val branchOptions: List<Int> = emptyList(),
     var action: CellAction? = null,
-    val isLottery: Boolean = false,
-    val isMinigame: Boolean = false
+    val type: String? = null
 ) {
     /**
      * Handles a player landing on the cell.

--- a/src/main/kotlin/at/mankomania/server/model/BoardFactory.kt
+++ b/src/main/kotlin/at/mankomania/server/model/BoardFactory.kt
@@ -29,4 +29,24 @@ object BoardFactory {
         }
         return Board(cells)
     }
+    fun createSimpleBoard(): Board {
+        val cells = mutableListOf<BoardCell>()
+
+        val branchFieldIndices = setOf(6, 14, 21, 30)
+        val startFieldIndices = setOf(0, 9, 18, 27)
+
+        for (i in 0 until 36) {
+            when {
+                i in startFieldIndices -> cells.add(BoardCell(index = i, hasBranch = false))
+                i in branchFieldIndices -> cells.add(
+                    BoardCell(index = i, hasBranch = true, branchOptions = listOf(100 + i))
+                )
+                else -> cells.add(BoardCell(index = i, hasBranch = false))
+            }
+        }
+
+        return Board(cells)
+    }
+
+
 }

--- a/src/main/kotlin/at/mankomania/server/model/BoardFactory.kt
+++ b/src/main/kotlin/at/mankomania/server/model/BoardFactory.kt
@@ -32,38 +32,35 @@ object BoardFactory {
     fun createSimpleBoard(): Board {
         val cells = mutableListOf<BoardCell>()
 
-        val startFieldIndices = setOf(0, 8, 13, 20)
+        val startFieldIndices = setOf(0, 12, 20, 32)
         val branchFieldMap = mapOf(
-            5 to listOf(24, 25),    // → M1
-            10 to listOf(26, 27),   // → M2
-            16 to listOf(28, 29),   // → M3
-            22 to listOf(30, 31)    // → M4
+            5 to listOf(6, 7, 8, 9),    // → M1
+            14 to listOf(15, 16, 17, 18),   // → M2
+            24 to listOf(25, 26, 27, 28),   // → M3
+            34 to listOf(35,36,37,38)    // → M4
         )
         val lotteryIndex = 3
-        val minigameIndices = setOf(25, 27, 29, 31)
 
-        for (i in 0 until 36) {
+        for (i in 0 until 40) {
             when {
-                i in startFieldIndices -> cells.add(BoardCell(index = i, hasBranch = false))
-                i == lotteryIndex -> {
-                    cells.add(BoardCell(index = i, hasBranch = false, isLottery = true))
-                }
-
-                i in branchFieldMap.keys -> {
-                    cells.add(
-                        BoardCell(index = i, hasBranch = true, branchOptions = branchFieldMap[i]!!)
-                    )
-                }
-                else -> cells.add(BoardCell(index = i, hasBranch = false))
+                i == lotteryIndex -> cells.add(BoardCell(index = i, hasBranch = false, type = "LOTTERY"))
+                i in startFieldIndices -> cells.add(BoardCell(index = i, hasBranch = false, type = "START"))
+                i in branchFieldMap.keys -> cells.add(BoardCell(index = i, hasBranch = true, branchOptions = branchFieldMap[i] ?: emptyList(), type = "BRANCH"))
+                else -> cells.add(BoardCell(index = i, hasBranch = false, type = "NORMAL"))
             }
         }
-        minigameIndices.forEach { i ->
-            cells.add(BoardCell(index = i, hasBranch = false, isMinigame = true))
-        }
 
+        var currentIndex = 40
+        for (branch in branchFieldMap.values) {
+            for (target in branch) {
+                cells.add(BoardCell(index = currentIndex++, hasBranch = false))
+            }
+        }
 
         return Board(cells)
     }
+
+
 
 
 }

--- a/src/main/kotlin/at/mankomania/server/model/BoardFactory.kt
+++ b/src/main/kotlin/at/mankomania/server/model/BoardFactory.kt
@@ -32,18 +32,35 @@ object BoardFactory {
     fun createSimpleBoard(): Board {
         val cells = mutableListOf<BoardCell>()
 
-        val branchFieldIndices = setOf(6, 14, 21, 30)
-        val startFieldIndices = setOf(0, 9, 18, 27)
+        val startFieldIndices = setOf(0, 8, 13, 20)
+        val branchFieldMap = mapOf(
+            5 to listOf(24, 25),    // → M1
+            10 to listOf(26, 27),   // → M2
+            16 to listOf(28, 29),   // → M3
+            22 to listOf(30, 31)    // → M4
+        )
+        val lotteryIndex = 3
+        val minigameIndices = setOf(25, 27, 29, 31)
 
         for (i in 0 until 36) {
             when {
                 i in startFieldIndices -> cells.add(BoardCell(index = i, hasBranch = false))
-                i in branchFieldIndices -> cells.add(
-                    BoardCell(index = i, hasBranch = true, branchOptions = listOf(100 + i))
-                )
+                i == lotteryIndex -> {
+                    cells.add(BoardCell(index = i, hasBranch = false, isLottery = true))
+                }
+
+                i in branchFieldMap.keys -> {
+                    cells.add(
+                        BoardCell(index = i, hasBranch = true, branchOptions = branchFieldMap[i]!!)
+                    )
+                }
                 else -> cells.add(BoardCell(index = i, hasBranch = false))
             }
         }
+        minigameIndices.forEach { i ->
+            cells.add(BoardCell(index = i, hasBranch = false, isMinigame = true))
+        }
+
 
         return Board(cells)
     }

--- a/src/main/kotlin/at/mankomania/server/model/BoardFactory.kt
+++ b/src/main/kotlin/at/mankomania/server/model/BoardFactory.kt
@@ -34,7 +34,7 @@ object BoardFactory {
 
         val startFieldIndices = setOf(0, 12, 20, 32)
         val branchFieldMap = mapOf(
-            5 to listOf(6, 7, 8, 9),    // → M1
+            4 to listOf(6, 7, 8, 9),    // → M1
             14 to listOf(15, 16, 17, 18),   // → M2
             24 to listOf(25, 26, 27, 28),   // → M3
             34 to listOf(35,36,37,38)    // → M4


### PR DESCRIPTION
Replaced placeholder board logic with createSimpleBoard() in BoardFactory.
Added support for:
4 fixed start cells 
4 branch cells with minigame paths 
Central lottery cell 
Added type: String? field to BoardCell for easier frontend rendering.

This PR belongs together with the [mankomania-client PR:
https://github.com/mankomania/mankomania-client/pull/63
 for consistent game board behavior.