### PR TITLE
adjust Staritng Positions

### DIFF
--- a/src/main/kotlin/at/mankomania/server/manager/GameSessionManager.kt
+++ b/src/main/kotlin/at/mankomania/server/manager/GameSessionManager.kt
@@ -59,9 +59,13 @@ class GameSessionManager(
         // 1) Assign starting money
         moneyAssigner.assignToAll(players)
 
-        // 2) Calculate fair, evenly spaced start positions
-        val startPositions = (0 until players.size).map { i -> (i * size) / players.size }
-        players.forEachIndexed { idx, player -> player.position = startPositions[idx] }
+        // 2) Exact Startpositions
+        val startPositions = listOf(0, 12, 32, 20)
+        players.forEachIndexed { idx, player ->
+            if (idx < startPositions.size) {
+                player.position = startPositions[idx]
+            }
+        }
 
         // 3) Create board and controller
         val board = BoardFactory.createSimpleBoard()

--- a/src/test/kotlin/at/mankomania/server/manager/GameSessionManagerTest.kt
+++ b/src/test/kotlin/at/mankomania/server/manager/GameSessionManagerTest.kt
@@ -67,11 +67,11 @@ class GameSessionManagerTest {
     @Test
     fun testStartSessionAssignsCorrectStartPositions() {
         // join 3 players directly in this test
-        listOf("P1", "P2", "P3").forEach { sessionManager.joinGame(gameId, it) }
+        listOf("P1", "P2", "P3", "P4").forEach { sessionManager.joinGame(gameId, it) }
         val positions = sessionManager.startSession(gameId, 40)
         assertNotNull(positions)
-        // expect evenly spaced positions: [0, 13, 26]
-        assertEquals(listOf(0, 13, 26), positions)
+        // expect evenly spaced positions: [0, 12, 32, 20]
+        assertEquals(listOf(0, 12, 32, 20), positions)
     }
 
     @Test


### PR DESCRIPTION
This PR adjusts the player starting positions to align with the current game board layout in the UI.
Players are now placed on the following fixed cells:

Player 1 → Cell 0
Player 2 → Cell 12
Player 3 → Cell 32
Player 4 → Cell 20

This ensures consistency between the backend logic and the visual representation of the board.