### PR TITLE
Fix/merge move computation

### DIFF
--- a/src/main/kotlin/at/mankomania/server/controller/GameController.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/GameController.kt
@@ -32,6 +32,8 @@ class GameController(
     fun startGame() {
         // Broadcast full game state (players + board) using DTO mapping
         notificationService.sendGameStateFromModels(gameId, players, board.cells)
+        // Broadcast all players' statuses
+        players.forEach { notificationService.sendPlayerStatus(it) }
     }
 
     /**

--- a/src/main/kotlin/at/mankomania/server/controller/GameController.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/GameController.kt
@@ -8,7 +8,7 @@
 
 package at.mankomania.server.controller
 
-import at.mankomania.server.controller.dto.GameStateDto
+
 import at.mankomania.server.model.Board
 import at.mankomania.server.model.MoveResult
 import at.mankomania.server.model.Player
@@ -30,9 +30,8 @@ class GameController(
      * Called once when a game session starts.
      */
     fun startGame() {
-        // Broadcast full game state (players + board)
-        val state = GameStateDto(players, board.cells)
-        notificationService.sendGameState(gameId, state)
+        // Broadcast full game state (players + board) using DTO mapping
+        notificationService.sendGameStateFromModels(gameId, players, board.cells)
     }
 
     /**
@@ -88,6 +87,9 @@ class GameController(
         board.getCell(cellIndex).landOn(player, this)
         notificationService.sendPlayerLanded(playerId, cellIndex)
         notificationService.sendPlayerStatus(player)
+
+        // Broadcast full game state after a move
+        notificationService.sendGameStateFromModels(gameId, players, board.cells)
     }
 
 }

--- a/src/main/kotlin/at/mankomania/server/controller/MoveController.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/MoveController.kt
@@ -3,6 +3,7 @@ package at.mankomania.server.controller
 import at.mankomania.server.controller.dto.MoveRequest
 import at.mankomania.server.manager.GameSessionManager
 import at.mankomania.server.model.MoveResult
+import at.mankomania.server.service.PlayerMoveService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
@@ -18,7 +19,8 @@ import org.springframework.web.bind.annotation.*
 @RestController
 @RequestMapping("/move")
 class MoveController(
-private val sessionManager: GameSessionManager
+private val sessionManager: GameSessionManager,
+private val playerMoveService: PlayerMoveService
 ) {
     /**
      * Handles a player move request for a specific game instance.
@@ -34,8 +36,7 @@ private val sessionManager: GameSessionManager
         @PathVariable gameId: String,
         @RequestBody request: MoveRequest
     ): ResponseEntity<MoveResult> {
-        val controller = sessionManager.getGameController(gameId) ?: return ResponseEntity.badRequest().build()
-        val result = controller.computeMoveResult(request.playerId, request.steps)
+        val result = playerMoveService.computeMove(gameId, request.playerId, request.steps)
             ?: return ResponseEntity.badRequest().build()
         return ResponseEntity.ok(result)
     }

--- a/src/main/kotlin/at/mankomania/server/controller/dto/GameStateDto.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/dto/GameStateDto.kt
@@ -1,9 +1,6 @@
 package at.mankomania.server.controller.dto
 
-import at.mankomania.server.model.BoardCell
-import at.mankomania.server.model.Player
-
 data class GameStateDto(
-    val players: List<Player>,
-    val board: List<BoardCell>
+    val players: List<PlayerDto>,
+    val board: List<CellDto>
 )

--- a/src/main/kotlin/at/mankomania/server/controller/dto/PlayerDto.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/dto/PlayerDto.kt
@@ -3,5 +3,7 @@ package at.mankomania.server.controller.dto
 
 data class PlayerDto(
     val name: String,
-    val position: Int
+    val position: Int,
+    val balance: Int,
+    val isTurn: Boolean
 )

--- a/src/main/kotlin/at/mankomania/server/manager/GameSessionManager.kt
+++ b/src/main/kotlin/at/mankomania/server/manager/GameSessionManager.kt
@@ -68,6 +68,8 @@ class GameSessionManager(
         players.forEachIndexed { index, player ->
             player.isTurn = (index == startingPlayerIndex)
         }
+        // Notify all players of their status for consistency
+        players.forEach { notificationService.sendPlayerStatus(it) }
 
         // 3) Create board and controller
         val board = BoardFactory.createBoard(size) { idx -> idx % 10 == 0 }

--- a/src/main/kotlin/at/mankomania/server/manager/GameSessionManager.kt
+++ b/src/main/kotlin/at/mankomania/server/manager/GameSessionManager.kt
@@ -63,6 +63,12 @@ class GameSessionManager(
         val startPositions = (0 until players.size).map { i -> (i * size) / players.size }
         players.forEachIndexed { idx, player -> player.position = startPositions[idx] }
 
+        // Select starting player randomly and mark as active/turn
+        val startingPlayerIndex = (players.indices).random()
+        players.forEachIndexed { index, player ->
+            player.isTurn = (index == startingPlayerIndex)
+        }
+
         // 3) Create board and controller
         val board = BoardFactory.createBoard(size) { idx -> idx % 10 == 0 }
         val controller = GameController(gameId, board, players, bankService, notificationService)

--- a/src/main/kotlin/at/mankomania/server/model/Player.kt
+++ b/src/main/kotlin/at/mankomania/server/model/Player.kt
@@ -14,7 +14,8 @@ data class Player(
     var position: Int = 0,
     var balance: Int = 0,
     val diceHistory: MutableList<DiceResult> = mutableListOf(),
-    var money: MutableMap<Int, Int>? = null
+    var money: MutableMap<Int, Int>? = null,
+    var isTurn: Boolean = false
 ) {
     /**
      * Moves the player forward on the board by a given number of steps.

--- a/src/main/kotlin/at/mankomania/server/service/NotificationService.kt
+++ b/src/main/kotlin/at/mankomania/server/service/NotificationService.kt
@@ -22,6 +22,32 @@ class NotificationService(private val messagingTemplate: SimpMessagingTemplate) 
         messagingTemplate.convertAndSend("/topic/game/state/$lobbyId", state)
     }
 
+    // Helper to convert server Player to PlayerDto
+    private fun toPlayerDto(player: Player): at.mankomania.server.controller.dto.PlayerDto {
+        return at.mankomania.server.controller.dto.PlayerDto(
+            name = player.name,
+            position = player.position
+        )
+    }
+
+    // Helper to convert BoardCell to CellDto
+    private fun toCellDto(cell: at.mankomania.server.model.BoardCell): at.mankomania.server.controller.dto.CellDto {
+        return at.mankomania.server.controller.dto.CellDto(
+            index = cell.index,
+            hasBranch = cell.hasBranch
+        )
+    }
+
+    /**
+     * Sends the game state using server models (Player, BoardCell), mapping to DTOs for the client.
+     */
+    fun sendGameStateFromModels(lobbyId: String, players: List<Player>, boardCells: List<at.mankomania.server.model.BoardCell>) {
+        val playerDtos = players.map { toPlayerDto(it) }
+        val cellDtos = boardCells.map { toCellDto(it) }
+        val state = at.mankomania.server.controller.dto.GameStateDto(playerDtos, cellDtos)
+        sendGameState(lobbyId, state)
+    }
+
     fun sendPlayerMoved(playerId: String, position: Int) {
         messagingTemplate.convertAndSend(
             "/topic/game/move",

--- a/src/main/kotlin/at/mankomania/server/service/NotificationService.kt
+++ b/src/main/kotlin/at/mankomania/server/service/NotificationService.kt
@@ -26,7 +26,9 @@ class NotificationService(private val messagingTemplate: SimpMessagingTemplate) 
     private fun toPlayerDto(player: Player): at.mankomania.server.controller.dto.PlayerDto {
         return at.mankomania.server.controller.dto.PlayerDto(
             name = player.name,
-            position = player.position
+            position = player.position,
+            balance = player.balance,
+            isTurn = player.isTurn
         )
     }
 
@@ -63,7 +65,7 @@ class NotificationService(private val messagingTemplate: SimpMessagingTemplate) 
     }
     /**
      * Sends the full player status over WebSocket.
-     * Includes name, position, balance, and money (denominations).
+     * Includes name, position, balance, money (denominations), and isTurn.
      *
      * @param player the player whose full state should be sent
      */
@@ -73,7 +75,8 @@ class NotificationService(private val messagingTemplate: SimpMessagingTemplate) 
             "name" to player.name,
             "position" to player.position,
             "balance" to player.balance,
-            "money" to player.money
+            "money" to player.money,
+            "isTurn" to player.isTurn
         )
         messagingTemplate.convertAndSend(destination, payload)
     }

--- a/src/main/kotlin/at/mankomania/server/service/PlayerMoveService.kt
+++ b/src/main/kotlin/at/mankomania/server/service/PlayerMoveService.kt
@@ -1,0 +1,14 @@
+package at.mankomania.server.service
+
+import at.mankomania.server.manager.GameSessionManager
+import at.mankomania.server.model.MoveResult
+import org.springframework.stereotype.Service
+
+@Service
+class PlayerMoveService (private val sessionManager: GameSessionManager){
+
+    fun computeMove(gameId: String, playerId: String, steps:Int): MoveResult? {
+        val controller = sessionManager.getGameController(gameId) ?: return null
+        return controller.computeMoveResult(playerId, steps)
+    }
+}

--- a/src/main/kotlin/at/mankomania/server/service/PlayerMoveService.kt
+++ b/src/main/kotlin/at/mankomania/server/service/PlayerMoveService.kt
@@ -1,3 +1,10 @@
+/**
+ * @file PlayerMoveService.kt
+ * @author Lev Starman
+ * @since 2025-06-21
+ * @description Central service to compute player movement consistently across controllers.
+ * Used by both REST (MoveController) and WebSocket (PlayerController) interfaces to ensure shared logic for move execution and result calculation.
+ */
 package at.mankomania.server.service
 
 import at.mankomania.server.manager.GameSessionManager

--- a/src/main/kotlin/at/mankomania/server/websocket/LobbyWebSoketController.kt
+++ b/src/main/kotlin/at/mankomania/server/websocket/LobbyWebSoketController.kt
@@ -59,7 +59,9 @@ class LobbyWebSocketController(
 
                 // Delay initial GameState broadcast by 200ms so client subscription can be set up
                 Executors.newSingleThreadScheduledExecutor().schedule({
-                    sessionManager.getGameController(message.lobbyId)?.startGame()
+                    //sessionManager.getGameController(message.lobbyId)?.startGame()
+                    // Do NOT call startGame() again here; already called by startSession()
+                    // sessionManager.getGameController(message.lobbyId)?.startGame()
                 }, 200, TimeUnit.MILLISECONDS)
 
                 return response

--- a/src/main/kotlin/at/mankomania/server/websocket/PlayerSocketService.kt
+++ b/src/main/kotlin/at/mankomania/server/websocket/PlayerSocketService.kt
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service
 @Service
 class PlayerSocketService(private val messagingTemplate: SimpMessagingTemplate) {
 
-    /**
+    /**w
      * Sends the current financial state of the given player via WebSocket.
      * The message is sent to the topic: /topic/player/{playerName}/money
      *

--- a/src/test/kotlin/at/mankomania/server/PlayerTest.kt
+++ b/src/test/kotlin/at/mankomania/server/PlayerTest.kt
@@ -1,4 +1,4 @@
-package at.mankomania.server
+package at.mankomania.server.test
 
 
 import at.mankomania.server.model.Board
@@ -162,5 +162,24 @@ class PlayerTest {
 
         assertEquals(1, player.diceHistory.size)
         assertEquals(result, player.diceHistory.first())
+    }
+    /**
+     * Verifies that balance and money are assigned when a player is created and money is distributed.
+     */
+    @Test
+    fun playerReceivesStartingMoneyAndBalance() {
+        val p = Player(name = "testplayer")
+        // Simulate assignment
+        val denominations = mapOf(
+            5_000 to 10,
+            10_000 to 5,
+            50_000 to 4,
+            100_000 to 7
+        )
+        val totalAmount = denominations.entries.sumOf { it.key * it.value }
+        p.balance = totalAmount
+        p.money = denominations.toMutableMap()
+        assertEquals(totalAmount, p.balance)
+        assertEquals<Map<Int, Int>>(denominations, p.money ?: error("Money should not be null"))
     }
 }

--- a/src/test/kotlin/at/mankomania/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/at/mankomania/server/controller/GameControllerTest.kt
@@ -1,6 +1,8 @@
 package at.mankomania.server.controller
 
+import at.mankomania.server.controller.dto.CellDto
 import at.mankomania.server.controller.dto.GameStateDto
+import at.mankomania.server.controller.dto.PlayerDto
 import at.mankomania.server.model.Board
 import at.mankomania.server.model.BoardCell
 import at.mankomania.server.model.BoardFactory
@@ -40,12 +42,15 @@ class GameControllerTest {
 
     @Test
     fun `startGame should broadcast correct initial state`() {
-        val expectedDto = GameStateDto(players, board.cells)
+        val expectedDto = GameStateDto(
+            players = players.map { PlayerDto(it.name, it.position) },
+            board = board.cells.map { CellDto(it.index, it.hasBranch) }
+        )
 
         controller.startGame()
 
         // direkte Objektreferenz, Data-Klassen haben equals() implementiert
-        verify(notificationService).sendGameState(testGameId, expectedDto)
+        verify(notificationService).sendGameStateFromModels(testGameId, players, board.cells)
     }
 
     @Test

--- a/src/test/kotlin/at/mankomania/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/at/mankomania/server/controller/GameControllerTest.kt
@@ -36,14 +36,17 @@ class GameControllerTest {
     @BeforeEach
     fun setUp() {
         board   = BoardFactory.createBoard(5) { false }
-        players = listOf(Player("Toni"), Player("Jorge"))
+        players = listOf(
+            Player(name = "Toni", balance = 0, isTurn = false),
+            Player(name = "Jorge", balance = 0, isTurn = false)
+        )
         controller = GameController(testGameId, board, players, bankService, notificationService)
     }
 
     @Test
     fun `startGame should broadcast correct initial state`() {
         val expectedDto = GameStateDto(
-            players = players.map { PlayerDto(it.name, it.position) },
+            players = players.map { PlayerDto(it.name, it.position, it.balance, it.isTurn) },
             board = board.cells.map { CellDto(it.index, it.hasBranch) }
         )
 

--- a/src/test/kotlin/at/mankomania/server/controller/MoveControllerTest.kt
+++ b/src/test/kotlin/at/mankomania/server/controller/MoveControllerTest.kt
@@ -3,6 +3,7 @@ package at.mankomania.server.controller
 import at.mankomania.server.controller.dto.MoveRequest
 import at.mankomania.server.manager.GameSessionManager
 import at.mankomania.server.model.MoveResult
+import at.mankomania.server.service.PlayerMoveService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
@@ -26,7 +27,8 @@ class MoveControllerTest {
     @BeforeEach
     fun setup() {
         sessionManager = Mockito.mock(GameSessionManager::class.java)
-        controller = MoveController(sessionManager)
+        val moveService = PlayerMoveService(sessionManager)
+        controller = MoveController(sessionManager, moveService)
     }
 
     /**

--- a/src/test/kotlin/at/mankomania/server/controller/PlayerControllerTest.kt
+++ b/src/test/kotlin/at/mankomania/server/controller/PlayerControllerTest.kt
@@ -12,6 +12,7 @@ import at.mankomania.server.controller.dto.DiceMoveResultDto
 import at.mankomania.server.controller.GameController
 import at.mankomania.server.manager.GameSessionManager
 import at.mankomania.server.model.MoveResult
+import at.mankomania.server.service.PlayerMoveService
 import at.mankomania.server.util.Dice
 import at.mankomania.server.util.DiceResult
 import org.junit.jupiter.api.BeforeEach
@@ -34,7 +35,8 @@ class PlayerControllerTest {
     fun setUp() {
         messagingTemplate = mock(SimpMessagingTemplate::class.java)
         sessionManager = mock(GameSessionManager::class.java)
-        controller = PlayerController(messagingTemplate, sessionManager)
+        val moveService = PlayerMoveService(sessionManager)
+        controller = PlayerController(messagingTemplate, sessionManager, moveService)
     }
 
     /**

--- a/src/test/kotlin/at/mankomania/server/manager/GameSessionManagerTest.kt
+++ b/src/test/kotlin/at/mankomania/server/manager/GameSessionManagerTest.kt
@@ -82,6 +82,16 @@ class GameSessionManagerTest {
         val controller = sessionManager.getGameController(gameId)
         assertNotNull(controller)
         assertTrue(controller is GameController)
+        // Verify sendPlayerStatus called with starting player
+        val startingPlayer = sessionManager.getPlayers(gameId).firstOrNull { it.isTurn }
+        if (startingPlayer != null) {
+            org.mockito.Mockito.verify(sessionManager
+                .javaClass
+                .getDeclaredField("notificationService")
+                .apply { isAccessible = true }
+                .get(sessionManager) as NotificationService
+            ).sendPlayerStatus(startingPlayer)
+        }
     }
 
     @Test

--- a/src/test/kotlin/at/mankomania/server/manager/GameSessionManagerTest.kt
+++ b/src/test/kotlin/at/mankomania/server/manager/GameSessionManagerTest.kt
@@ -9,12 +9,16 @@ import at.mankomania.server.websocket.PlayerSocketService
 import kotlin.test.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito.atLeastOnce
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
 
 class GameSessionManagerTest {
 
+    private lateinit var notificationService: NotificationService
     private lateinit var sessionManager: GameSessionManager
     private val gameId = "testGame"
+
     @BeforeEach
     fun setUp() {
         val playerSocketService = mock(PlayerSocketService::class.java)
@@ -79,18 +83,22 @@ class GameSessionManagerTest {
         // join 3 players directly in this test
         listOf("P1", "P2", "P3").forEach { sessionManager.joinGame(gameId, it) }
         sessionManager.startSession(gameId, 40)
+
+        // verify controller creation
         val controller = sessionManager.getGameController(gameId)
         assertNotNull(controller)
         assertTrue(controller is GameController)
-        // Verify sendPlayerStatus called with starting player
+
+        // retrieve starting player and verify notification was sent
         val startingPlayer = sessionManager.getPlayers(gameId).firstOrNull { it.isTurn }
         if (startingPlayer != null) {
-            org.mockito.Mockito.verify(sessionManager
+            val field = sessionManager
                 .javaClass
                 .getDeclaredField("notificationService")
                 .apply { isAccessible = true }
-                .get(sessionManager) as NotificationService
-            ).sendPlayerStatus(startingPlayer)
+
+            val realNotificationService = field.get(sessionManager) as NotificationService
+            verify(realNotificationService, atLeastOnce()).sendPlayerStatus(startingPlayer)
         }
     }
 

--- a/src/test/kotlin/at/mankomania/server/service/NotificationServiceTest.kt
+++ b/src/test/kotlin/at/mankomania/server/service/NotificationServiceTest.kt
@@ -70,7 +70,8 @@ class NotificationServiceTest {
             "name" to "TestUser",
             "position" to 6,
             "balance" to 70000,
-            "money" to mapOf(5000 to 6, 10000 to 2)
+            "money" to mapOf(5000 to 6, 10000 to 2),
+            "isTurn" to false
         )
 
         Mockito.verify(messagingTemplate).convertAndSend(

--- a/src/test/kotlin/at/mankomania/server/service/NotificationServiceTest.kt
+++ b/src/test/kotlin/at/mankomania/server/service/NotificationServiceTest.kt
@@ -2,10 +2,28 @@ package at.mankomania.server.service
 
 import at.mankomania.server.controller.dto.GameStateDto
 import at.mankomania.server.model.Player
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito.mock
 import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.mockito.Mockito.verify
+
+/**
+ * @file NotificationServiceTest.kt
+ * @author Angela Drucks, Lev Starman
+ * @since 2025-05-07
+ * @description
+ * Unit tests for NotificationService. Verifies correct WebSocket/STOMP broadcasting of:
+ * - game state updates (GameStateDto)
+ * - player movement and landing events
+ * - full player status including balance, money breakdown, and turn info
+ *
+ * Ensures that all WebSocket destinations and payloads are correctly formatted and invoked.
+ */
 
 class NotificationServiceTest {
 
@@ -14,7 +32,7 @@ class NotificationServiceTest {
 
     @BeforeEach
     fun setup() {
-        messagingTemplate = Mockito.mock(SimpMessagingTemplate::class.java)
+        messagingTemplate = mock(SimpMessagingTemplate::class.java)
         notificationService = NotificationService(messagingTemplate)
     }
 
@@ -27,7 +45,7 @@ class NotificationServiceTest {
 
         notificationService.sendGameState("LOBBY1", state)
 
-        Mockito.verify(messagingTemplate).convertAndSend(
+        verify(messagingTemplate).convertAndSend(
             "/topic/game/state/LOBBY1",
             state
         )
@@ -38,7 +56,7 @@ class NotificationServiceTest {
         notificationService.sendPlayerMoved("Alice", 3)
 
         val expected = mapOf("player" to "Alice", "position" to 3)
-        Mockito.verify(messagingTemplate).convertAndSend(
+        verify(messagingTemplate).convertAndSend(
             "/topic/game/move",
             expected
         )
@@ -49,7 +67,7 @@ class NotificationServiceTest {
         notificationService.sendPlayerLanded("Bob", 5)
 
         val expected = mapOf("player" to "Bob", "position" to 5)
-        Mockito.verify(messagingTemplate).convertAndSend(
+        verify(messagingTemplate).convertAndSend(
             "/topic/game/land",
             expected
         )
@@ -74,9 +92,44 @@ class NotificationServiceTest {
             "isTurn" to false
         )
 
-        Mockito.verify(messagingTemplate).convertAndSend(
+        verify(messagingTemplate).convertAndSend(
             "/topic/player/TestUser/status",
             expectedPayload
         )
+    }
+    @Test
+    fun `sendGameStateFromModels should convert and send DTOs`() {
+        // Arrange: create a sample player and board cell
+        val player = Player(name = "TestUser", position = 2, balance = 50000, isTurn = true)
+        val boardCell = at.mankomania.server.model.BoardCell(index = 2, hasBranch = true)
+
+        // Act: call the function
+        notificationService.sendGameStateFromModels("LOBBY2", listOf(player), listOf(boardCell))
+
+        // Assert: capture and inspect the argument
+        val captor = ArgumentCaptor.forClass(Any::class.java)
+        verify(messagingTemplate).convertAndSend(eq("/topic/game/state/LOBBY2"), captor.capture())
+
+        // Verify that the sent object is a GameStateDto and contains our test player
+        val sent = captor.value
+        assertTrue(sent is GameStateDto)
+        val dto = sent as GameStateDto
+        assertEquals("TestUser", dto.players.first().name)
+        assertEquals(2, dto.board.first().index)
+        assertTrue(dto.board.first().hasBranch)
+    }
+
+    @Test
+    fun `sendPlayerMoved should send correct player and edge position`() {
+        notificationService.sendPlayerMoved("EdgePlayer", 0)
+        val expected = mapOf("player" to "EdgePlayer", "position" to 0)
+        verify(messagingTemplate).convertAndSend("/topic/game/move", expected)
+    }
+
+    @Test
+    fun `sendPlayerLanded should send landing at last field`() {
+        notificationService.sendPlayerLanded("TopPlayer", 39)
+        val expected = mapOf("player" to "TopPlayer", "position" to 39)
+        verify(messagingTemplate).convertAndSend("/topic/game/land", expected)
     }
 }

--- a/src/test/kotlin/at/mankomania/server/service/PlayerMoveServiceTest.kt
+++ b/src/test/kotlin/at/mankomania/server/service/PlayerMoveServiceTest.kt
@@ -1,0 +1,68 @@
+/**
+ * @file PlayerMoveServiceTest.kt
+ * @author Lev Starman
+ * @since 2025-06-21
+ * @description Unit tests for PlayerMoveService, ensuring correct computation of player moves across different edge cases.
+ */
+package at.mankomania.server.service
+
+import at.mankomania.server.controller.GameController
+import at.mankomania.server.manager.GameSessionManager
+import at.mankomania.server.model.BoardFactory
+import at.mankomania.server.model.Player
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+
+class PlayerMoveServiceTest {
+
+    private lateinit var sessionManager: GameSessionManager
+    private lateinit var playerMoveService: PlayerMoveService
+    private lateinit var controller: GameController
+
+    private val gameId = "test-game"
+    private val playerId = "TestPlayer"
+
+    @BeforeEach
+    fun setup() {
+        sessionManager = mock(GameSessionManager::class.java)
+        playerMoveService = PlayerMoveService(sessionManager)
+
+        val board = BoardFactory.createBoard(5) { false }
+        val players = listOf(Player(name = playerId))
+        controller = GameController(gameId, board, players, mock(BankService::class.java), mock(NotificationService::class.java))
+
+        `when`(sessionManager.getGameController(gameId)).thenReturn(controller)
+    }
+
+    /**
+     * Tests that a known player within an active game session
+     * receives a valid MoveResult from the PlayerMoveService.
+     */
+    @Test
+    fun `computeMove should return a valid result for existing player`() {
+        val result = playerMoveService.computeMove(gameId, playerId, 2)
+        assertNotNull(result)
+        assertEquals(playerId, controller.getPlayer(playerId)?.name)
+    }
+
+    /**
+     * Tests that PlayerMoveService returns null for a non-existent player.
+     */
+    @Test
+    fun `computeMove should return null for invalid player`() {
+        val result = playerMoveService.computeMove(gameId, "Unknown", 2)
+        assertNull(result)
+    }
+
+    /**
+     * Tests that PlayerMoveService returns null when no GameController is found for the gameId.
+     */
+    @Test
+    fun `computeMove should return null if no controller is found`() {
+        `when`(sessionManager.getGameController("invalid")).thenReturn(null)
+        val result = playerMoveService.computeMove("invalid", playerId, 2)
+        assertNull(result)
+    }
+}


### PR DESCRIPTION
Created PlayerMoveService to centralize and reuse player move logic across both WebSocket (PlayerController) and REST (MoveController) interfaces.
This change:
	•	Ensures consistent behavior across controllers
	•	Reduces code duplication
	•	Simplifies future updates to move-related logic

This refactor improves maintainability and prepares the codebase for more scalable player action handling.

Note: This branch was originally branched off feature/10-refactor-dto-game-state-sync, so it includes some unrelated commits from that branch. However, the only relevant changes for this PR are in:
	•	**PlayerMoveService.kt
	•	PlayerController.kt
	•	MoveController.kt**