### PR TITLE
Fix/movement rescue server

### DIFF
--- a/src/main/kotlin/at/mankomania/server/controller/GameController.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/GameController.kt
@@ -14,6 +14,7 @@ import at.mankomania.server.model.MoveResult
 import at.mankomania.server.model.Player
 import at.mankomania.server.service.BankService
 import at.mankomania.server.service.NotificationService
+import at.mankomania.server.controller.dto.PlayerDto
 
 
 class GameController(
@@ -34,7 +35,11 @@ class GameController(
         // Broadcast full game state (players + board)
         currentPlayerIndex = 0
         val currentPlayer:Player = players[currentPlayerIndex]
-        val state = GameStateDto(players, board.cells, currentPlayer.name)
+        val state = GameStateDto(
+            players = players.map { PlayerDto(it.name, it.position) },
+            board = board.cells,
+            currentPlayer = currentPlayer.name
+        )
         notificationService.sendGameState(gameId, state)
     }
 
@@ -49,7 +54,11 @@ class GameController(
         val nextPlayer: Player = players[currentPlayerIndex]
         notificationService.sendPlayerMoved(playerId, player.position)
         notificationService.sendPlayerStatus(player)
-        val updatedState = GameStateDto(players, board.cells, nextPlayer.name)
+        val updatedState = GameStateDto(
+            players = players.map { PlayerDto(it.name, it.position) },
+            board = board.cells,
+            currentPlayer = nextPlayer.name
+        )
         notificationService.sendGameState(gameId, updatedState)
     }
 

--- a/src/main/kotlin/at/mankomania/server/controller/GameController.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/GameController.kt
@@ -40,6 +40,7 @@ class GameController(
             board = board.cells,
             currentTurnPlayerName = currentPlayer.name
         )
+        println("DEBUG: currentPlayer.name = '${currentPlayer.name}'")
         notificationService.sendGameState(gameId, state)
     }
 

--- a/src/main/kotlin/at/mankomania/server/controller/GameController.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/GameController.kt
@@ -38,7 +38,7 @@ class GameController(
         val state = GameStateDto(
             players = players.map { PlayerDto(it.name, it.position) },
             board = board.cells,
-            currentPlayer = currentPlayer.name
+            currentTurnPlayerName = currentPlayer.name
         )
         notificationService.sendGameState(gameId, state)
     }
@@ -57,7 +57,7 @@ class GameController(
         val updatedState = GameStateDto(
             players = players.map { PlayerDto(it.name, it.position) },
             board = board.cells,
-            currentPlayer = nextPlayer.name
+            currentTurnPlayerName = nextPlayer.name
         )
         notificationService.sendGameState(gameId, updatedState)
     }

--- a/src/main/kotlin/at/mankomania/server/controller/dto/GameStateDto.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/dto/GameStateDto.kt
@@ -5,5 +5,6 @@ import at.mankomania.server.model.Player
 
 data class GameStateDto(
     val players: List<Player>,
-    val board: List<BoardCell>
+    val board: List<BoardCell>,
+    val currentPlayer: String
 )

--- a/src/main/kotlin/at/mankomania/server/controller/dto/GameStateDto.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/dto/GameStateDto.kt
@@ -6,5 +6,5 @@ import at.mankomania.server.model.Player
 data class GameStateDto(
     val players: List<PlayerDto>,
     val board: List<BoardCell>,
-    val currentPlayer: String
+    val currentTurnPlayerName: String = ""
 )

--- a/src/main/kotlin/at/mankomania/server/controller/dto/GameStateDto.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/dto/GameStateDto.kt
@@ -1,7 +1,6 @@
 package at.mankomania.server.controller.dto
 
 import at.mankomania.server.model.BoardCell
-import at.mankomania.server.model.Player
 
 data class GameStateDto(
     val players: List<PlayerDto>,

--- a/src/main/kotlin/at/mankomania/server/controller/dto/GameStateDto.kt
+++ b/src/main/kotlin/at/mankomania/server/controller/dto/GameStateDto.kt
@@ -4,7 +4,7 @@ import at.mankomania.server.model.BoardCell
 import at.mankomania.server.model.Player
 
 data class GameStateDto(
-    val players: List<Player>,
+    val players: List<PlayerDto>,
     val board: List<BoardCell>,
     val currentPlayer: String
 )

--- a/src/main/kotlin/at/mankomania/server/manager/GameSessionManager.kt
+++ b/src/main/kotlin/at/mankomania/server/manager/GameSessionManager.kt
@@ -74,6 +74,7 @@ class GameSessionManager(
 
         // 4) Start the game
         controller.startGame()
+        println("Starting game for lobby $gameId – first player is: ${players.firstOrNull()?.name}")
 
         return startPositions
     }

--- a/src/test/kotlin/at/mankomania/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/at/mankomania/server/controller/GameControllerTest.kt
@@ -44,7 +44,7 @@ class GameControllerTest {
         val expectedDto = GameStateDto(
             players = players.map { PlayerDto(it.name, it.position) },
             board = board.cells,
-            currentTurnPlayerName = "Dummy"
+            currentTurnPlayerName = players.first().name
         )
 
         controller.startGame()

--- a/src/test/kotlin/at/mankomania/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/at/mankomania/server/controller/GameControllerTest.kt
@@ -44,7 +44,7 @@ class GameControllerTest {
         val expectedDto = GameStateDto(
             players = players.map { PlayerDto(it.name, it.position) },
             board = board.cells,
-            currentPlayer = "Dummy"
+            currentTurnPlayerName = "Dummy"
         )
 
         controller.startGame()

--- a/src/test/kotlin/at/mankomania/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/at/mankomania/server/controller/GameControllerTest.kt
@@ -7,6 +7,7 @@ import at.mankomania.server.model.BoardFactory
 import at.mankomania.server.model.Player
 import at.mankomania.server.service.NotificationService
 import at.mankomania.server.service.BankService
+import at.mankomania.server.controller.dto.PlayerDto
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -40,7 +41,11 @@ class GameControllerTest {
 
     @Test
     fun `startGame should broadcast correct initial state`() {
-        val expectedDto = GameStateDto(players, board.cells)
+        val expectedDto = GameStateDto(
+            players = players.map { PlayerDto(it.name, it.position) },
+            board = board.cells,
+            currentPlayer = "Dummy"
+        )
 
         controller.startGame()
 

--- a/src/test/kotlin/at/mankomania/server/service/NotificationServiceTest.kt
+++ b/src/test/kotlin/at/mankomania/server/service/NotificationServiceTest.kt
@@ -23,7 +23,7 @@ class NotificationServiceTest {
         val state = GameStateDto(
             players = listOf(),
             board = listOf(),
-            currentPlayer = "Dummy"
+            currentTurnPlayerName = "Dummy"
         )
 
         notificationService.sendGameState("LOBBY1", state)

--- a/src/test/kotlin/at/mankomania/server/service/NotificationServiceTest.kt
+++ b/src/test/kotlin/at/mankomania/server/service/NotificationServiceTest.kt
@@ -22,7 +22,8 @@ class NotificationServiceTest {
     fun `sendGameState should broadcast full game state to correct topic`() {
         val state = GameStateDto(
             players = listOf(),
-            board = listOf()
+            board = listOf(),
+            currentPlayer = "Dummy"
         )
 
         notificationService.sendGameState("LOBBY1", state)


### PR DESCRIPTION
This PR restores and stabilizes parts of the movement and turn-handling logic on the server side:

Ensures that turnPlayer is correctly assigned on game start and updated after eacht turn.

Improved logging inside GameService and WebSocketController to trace turn state.

Known Issue
Although the correct turnPlayer is being set server-side, there still seem to be sync issues on the client 



This PR complements the changes in  https://github.com/mankomania/mankomania-client/pull/71